### PR TITLE
misc framework updates (scm version, contrib guide, tag comment bot)

### DIFF
--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -1,0 +1,47 @@
+name: Comment Bot
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  tag:
+    if: startsWith(github.event.comment.body, '/tag ')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: React Seen
+      uses: actions/github-script@v2
+      with:
+        script: |
+          post = context.eventName === 'issue_comment' ? github.reactions.createForIssueComment : github.reactions.createForPullRequestReviewComment
+          post({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: context.payload.comment.id,
+            content: "eyes",
+          })
+    - name: Tag Commit
+      run: |
+        git config user.name tag-bot
+        git config user.email casperdcl@noreply.github.com
+        git tag $(echo "$BODY" | awk '{print $2" "$3}')
+        git push --tags
+      env:
+        BODY: ${{ github.event.comment.body }}
+    - name: React Success
+      uses: actions/github-script@v2
+      with:
+        script: |
+          post = context.eventName === 'issue_comment' ? github.reactions.createForIssueComment : github.reactions.createForPullRequestReviewComment
+          post({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: context.payload.comment.id,
+            content: "rocket",
+          })
+  always:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo prevent failure when other jobs are skipped

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Packages
 shtab.egg-info/
+/.eggs/
 /build/
 /dist/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,3 +35,10 @@ string snippets without clashing between python's `str.format` and shell
 parameter expansion.
 
 The generated shell code itself is also meant to be readable.
+
+## Releases
+
+Tests and deployment are handled automatically by continuous integration. Simply
+tag a commit `v{major}.{minor}.{patch}` and wait for a draft release to appear
+at <https://github.com/iterative/shtab/releases>. Tidy up the draft's
+description before publishing it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,6 @@ Tests and deployment are handled automatically by continuous integration. Simply
 tag a commit `v{major}.{minor}.{patch}` and wait for a draft release to appear
 at <https://github.com/iterative/shtab/releases>. Tidy up the draft's
 description before publishing it.
+
+Note that tagging a release is possible by commenting `/tag vM.m.p HASH` in an
+issue or PR.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ except ImportError:
 
 __author__ = "Casper da Costa-Luis <casper.dcl@physics.org>"
 __licence__ = "Apache-2.0"
-__version__ = "1.0.4"
 src_dir = os.path.abspath(os.path.dirname(__file__))
 
 # Execute Makefile commands if specified
@@ -31,7 +30,8 @@ with io_open(requirements_dev, mode="r", encoding="utf-8") as fd:
     requirements_dev = fd.readlines()
 setup(
     name="shtab",
-    version=__version__,
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     description="Automatically generate shell tab completion scripts"
     " for python CLI apps",
     long_description=README_rst,

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -14,19 +14,31 @@ from argparse import (
 )
 from functools import total_ordering
 
-# N.B. if running from local repo but `setuptools_scm` is not importable,
-# then __version__ will be wrongly obtained from an installed distribution
-try:  # running from local repo
-    from setuptools_scm import get_version
 
-    __version__ = get_version(root="..", relative_to=__file__)
-except (ImportError, LookupError):  # installed
+def get_version_dist(name=__name__):
     from pkg_resources import DistributionNotFound, get_distribution
 
     try:
-        __version__ = get_distribution(__name__).version
+        return get_distribution(name).version
     except DistributionNotFound:
-        __version__ = "UNKNOWN"
+        return "UNKNOWN"
+
+
+try:
+    from setuptools_scm import get_version
+except ImportError:
+    from os import path
+
+    ROOT = path.abspath(path.dirname(path.dirname(__file__)))
+    if path.exists(path.join(ROOT, ".git")):
+        __version__ = "UNKNOWN - please install setuptools_scm"
+    else:
+        __version__ = get_version_dist()
+else:
+    try:
+        __version__ = get_version(root="..", relative_to=__file__)
+    except LookupError:
+        __version__ = get_version_dist()
 __all__ = ["Optional", "Required", "Choice", "complete"]
 log = logging.getLogger(__name__)
 

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -14,6 +14,19 @@ from argparse import (
 )
 from functools import total_ordering
 
+# N.B. if running from local repo but `setuptools_scm` is not importable,
+# then __version__ will be wrongly obtained from an installed distribution
+try:  # running from local repo
+    from setuptools_scm import get_version
+
+    __version__ = get_version(root="..", relative_to=__file__)
+except (ImportError, LookupError):  # installed
+    from pkg_resources import DistributionNotFound, get_distribution
+
+    try:
+        __version__ = get_distribution(__name__).version
+    except DistributionNotFound:
+        __version__ = "UNKNOWN"
 __all__ = ["Optional", "Required", "Choice", "complete"]
 log = logging.getLogger(__name__)
 

--- a/shtab/main.py
+++ b/shtab/main.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 from importlib import import_module
 
-from . import complete
+from . import __version__, complete
 
 log = logging.getLogger(__name__)
 
@@ -13,6 +13,9 @@ def get_main_parser():
     parser = argparse.ArgumentParser(prog="shtab")
     parser.add_argument(
         "parser", help="importable parser (or fuction returning parser)"
+    )
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s " + __version__
     )
     parser.add_argument(
         "-s", "--shell", default="bash", choices=["bash", "zsh"]


### PR DESCRIPTION
- [x] `use_scm_version` to simply use git tags to infer version
  + [x] expose version in `main.py` to allow `shtab --version` - see caveat below
- [x] update contributing guide
- [x] add a `Comment Bot` action
  + tagging a release is possible by commenting `/tag vM.m.p HASH` in an issue or PR :)

@shcheklein / @efiop about `use_scm_version` - maybe this approach would make life much easier for DVC too?
The issue is running directly from a repo (appending to `PYTHONPATH` without installing).
The easiest fix is to use 56eca525dc4b6c9edd67b696b87515e021e2f1f5 (which has a minor caveat of requiring `setuptools_scm` if running from a local repo). 8263506ba5f5e3d1c260d5aebb5111aecc27d700 improves on this further by outputting a helpful `UNKNOWN - please install setuptools-scm` message if people run `shtab --version` in this very unlikely scenario.

Overall looks much simpler and easy to maintain with no real downsides.