### PR TITLE
next release v1.1.0

### DIFF
--- a/.github/workflows/comment-bot.yml
+++ b/.github/workflows/comment-bot.yml
@@ -24,12 +24,13 @@ jobs:
           })
     - name: Tag Commit
       run: |
-        git config user.name tag-bot
-        git config user.email casperdcl@noreply.github.com
-        git tag $(echo "$BODY" | awk '{print $2" "$3}')
-        git push --tags
+        git clone https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} repo
+        git -C repo tag $(echo "$BODY" | awk '{print $2" "$3}')
+        git -C repo push --tags
+        rm -rf repo
       env:
         BODY: ${{ github.event.comment.body }}
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     - name: React Success
       uses: actions/github-script@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         echo "::set-output name=asset_path::$(ls dist/*.whl)"
         echo "::set-output name=asset_name::$(basename dist/*.whl)"
-        git fetch --tags
+        git fetch --unshallow
         changes="$(git log --format='format:%d %B %N' $(git tag --sort=v:refname | tail -n2 | xargs | awk '{print $1".."$2}'))"
         changes="${changes//'%'/'%25'}"
         changes="${changes//$'\n'/'%0A'}"

--- a/README.rst
+++ b/README.rst
@@ -228,9 +228,9 @@ Add direct support to scripts for a little more configurability:
             choices=["bash", "zsh"],
             help="prints completion script",
         )
-        # "file" & "directory" tab complete
-        parser.add_argument("file", nargs="?").complete = "file"
-        parser.add_argument("--dir", default=".").complete = "directory"
+        # file & directory tab complete
+        parser.add_argument("file", nargs="?").complete = shtab.FILE
+        parser.add_argument("--dir", default=".").complete = shtab.DIRECTORY
         return parser
 
     if __name__ == "__main__":

--- a/README.rst
+++ b/README.rst
@@ -223,28 +223,26 @@ Add direct support to scripts for a little more configurability:
     def get_main_parser():
         parser = argparse.ArgumentParser(prog="pathcomplete")
         parser.add_argument(
-            "-s", "--print-completion-shell", choices=["bash", "zsh"]
+            "-s",
+            "--print-completion-shell",
+            choices=["bash", "zsh"],
+            help="prints completion script",
         )
-        parser.add_argument(
-            "--file",
-            choices=shtab.Optional.FILE,  # file tab completion, can be blank
-        )
-        parser.add_argument(
-            "--dir",
-            choices=shtab.Required.DIRECTORY,  # directory tab completion
-            default=".",
-        )
+        # "file" & "directory" tab complete
+        parser.add_argument("file", nargs="?").complete = "file"
+        parser.add_argument("--dir", default=".").complete = "directory"
         return parser
 
     if __name__ == "__main__":
         parser = get_main_parser()
         args = parser.parse_args()
-        print("received --file='%s' --dir='%s'" % (args.file, args.dir))
 
         # completion magic
         shell = args.print_completion_shell
         if shell:
             print(shtab.complete(parser, shell=shell))
+        else:
+            print("received <file>=%r --dir=%r" % (args.file, args.dir))
 
 docopt
 ~~~~~~

--- a/examples/customcomplete.py
+++ b/examples/customcomplete.py
@@ -8,9 +8,9 @@ import argparse
 
 import shtab  # for completion magic
 
-CHOICE_FUNCTIONS = {
-    "bash": {"*.txt": "_shtab_greeter_compgen_TXTFiles"},
-    "zsh": {"*.txt": "_files -g '(*.txt|*.TXT)'"},
+TXT_FILE = {
+    "bash": "_shtab_greeter_compgen_TXTFiles",
+    "zsh": "_files -g '(*.txt|*.TXT)'",
 }
 PREAMBLE = {
     "bash": """
@@ -25,27 +25,26 @@ _shtab_greeter_compgen_TXTFiles() {
 }
 
 
-class Optional(shtab.Required):
-    TXT_FILE = [shtab.Choice("*.txt", required=False)]
-
-
-class Required(shtab.Required):
-    TXT_FILE = [shtab.Choice("*.txt", required=True)]
-
-
 def get_main_parser():
     parser = argparse.ArgumentParser(prog="customcomplete")
     parser.add_argument(
-        "-s", "--print-completion-shell", choices=["bash", "zsh"]
+        "-s",
+        "--print-completion-shell",
+        choices=["bash", "zsh"],
+        help="prints completion script",
     )
+    # `*.txt` file tab completion
+    parser.add_argument("input_txt", nargs="?").complete = TXT_FILE
+    # "file" tab completion builtin shortcut
+    parser.add_argument("-i", "--input-file").complete = "file"
     parser.add_argument(
         "-o",
-        "--output-txt",
-        choices=Optional.TXT_FILE,  # *.txt file tab completion, can be blank
-    )
-    parser.add_argument(
-        "input_txt", choices=Required.TXT_FILE,  # cannot be blank
-    )
+        "--output-name",
+        help=(
+            "output file name. Completes directory names to avoid users"
+            " accidentally overwriting existing files."
+        ),
+    ).complete = "directory"  # "directory" tab completion builtin shortcut
     return parser
 
 
@@ -56,15 +55,10 @@ if __name__ == "__main__":
     # completion magic
     shell = args.print_completion_shell
     if shell:
-        script = shtab.complete(
-            parser,
-            shell=shell,
-            preamble=PREAMBLE[shell],
-            choice_functions=CHOICE_FUNCTIONS[shell],
-        )
+        script = shtab.complete(parser, shell=shell, preamble=PREAMBLE)
         print(script)
     else:
         print(
-            "received input_txt='%s' --output-txt='%s'"
-            % (args.input_txt, args.output_txt)
+            "received <input_txt>=%r --output-dir=%r --output-name=%r"
+            % (args.input_txt, args.output_dir, args.output_name)
         )

--- a/examples/customcomplete.py
+++ b/examples/customcomplete.py
@@ -35,8 +35,8 @@ def get_main_parser():
     )
     # `*.txt` file tab completion
     parser.add_argument("input_txt", nargs="?").complete = TXT_FILE
-    # "file" tab completion builtin shortcut
-    parser.add_argument("-i", "--input-file").complete = "file"
+    # file tab completion builtin shortcut
+    parser.add_argument("-i", "--input-file").complete = shtab.FILE
     parser.add_argument(
         "-o",
         "--output-name",
@@ -44,7 +44,7 @@ def get_main_parser():
             "output file name. Completes directory names to avoid users"
             " accidentally overwriting existing files."
         ),
-    ).complete = "directory"  # "directory" tab completion builtin shortcut
+    ).complete = shtab.DIRECTORY  # directory tab completion builtin shortcut
     return parser
 
 

--- a/examples/pathcomplete.py
+++ b/examples/pathcomplete.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 """
 `argparse`-based CLI app using
-`add_argument(choices=shtab.(Optional|Required).(FILE|DIR)`
-for file/directory completion.
+`add_argument().complete = "file" or "directory"` for file/dir tab completion.
 
 See `customcomplete.py` for a more advanced version.
 """
@@ -14,17 +13,14 @@ import shtab  # for completion magic
 def get_main_parser():
     parser = argparse.ArgumentParser(prog="pathcomplete")
     parser.add_argument(
-        "-s", "--print-completion-shell", choices=["bash", "zsh"]
+        "-s",
+        "--print-completion-shell",
+        choices=["bash", "zsh"],
+        help="prints completion script",
     )
-    parser.add_argument(
-        "--file",
-        choices=shtab.Optional.FILE,  # file tab completion, can be blank
-    )
-    parser.add_argument(
-        "--dir",
-        choices=shtab.Required.DIRECTORY,  # directory tab completion
-        default=".",
-    )
+    # "file" & "directory" tab complete
+    parser.add_argument("file", nargs="?").complete = "file"
+    parser.add_argument("--dir", default=".").complete = "directory"
     return parser
 
 
@@ -37,4 +33,4 @@ if __name__ == "__main__":
     if shell:
         print(shtab.complete(parser, shell=shell))
     else:
-        print("received --file='%s' --dir='%s'" % (args.file, args.dir))
+        print("received <file>=%r --dir=%r" % (args.file, args.dir))

--- a/examples/pathcomplete.py
+++ b/examples/pathcomplete.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 `argparse`-based CLI app using
-`add_argument().complete = "file" or "directory"` for file/dir tab completion.
+`add_argument().complete = shtab.(FILE|DIR)` for file/dir tab completion.
 
 See `customcomplete.py` for a more advanced version.
 """
@@ -18,9 +18,9 @@ def get_main_parser():
         choices=["bash", "zsh"],
         help="prints completion script",
     )
-    # "file" & "directory" tab complete
-    parser.add_argument("file", nargs="?").complete = "file"
-    parser.add_argument("--dir", default=".").complete = "directory"
+    # file & directory tab complete
+    parser.add_argument("file", nargs="?").complete = shtab.FILE
+    parser.add_argument("--dir", default=".").complete = shtab.DIRECTORY
     return parser
 
 

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -150,7 +150,6 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
         """Flattened list of all `parser`'s optional actions."""
         return sum(
             (
-                # TODO: if hasattr(opt, "complete")?
                 opt.option_strings
                 for opt in parser._get_optional_actions()
                 if opt.help != SUPPRESS

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -46,6 +46,8 @@ CHOICE_FUNCTIONS = {
     "file": {"bash": "_shtab_compgen_files", "zsh": "_files"},
     "directory": {"bash": "_shtab_compgen_dirs", "zsh": "_files -/"},
 }
+FILE = CHOICE_FUNCTIONS["file"]
+DIRECTORY = DIR = CHOICE_FUNCTIONS["directory"]
 FLAG_OPTION = (
     _StoreConstAction,
     _HelpAction,


### PR DESCRIPTION
- add new custom-complete API `add_argument().complete = shtab.FILE or shtab.DIR or dict(zsh=..., bash=...)` (#9)
  + support `bash`
  + support `zsh`
- update documentation
  + update `README.rst`
  + update `examples/*.py`
  + remove all mention of old `choices` API
- misc CI framework updates
  + fix autogenerated changelog missing info
  + fix tags not triggering CI

---

- fixes #9