### PR TITLE
Add cli option to specify program name

### DIFF
--- a/shtab/main.py
+++ b/shtab/main.py
@@ -24,7 +24,9 @@ def get_main_parser():
         "--prefix", help="prepended to generated functions to avoid clashes"
     )
     parser.add_argument("--preamble", help="prepended to generated script")
-    parser.add_argument("--prog", help="custom program name (do not use parser.prog)")
+    parser.add_argument(
+        "--prog", help="custom program name (overrides `parser.prog`)"
+    )
     parser.add_argument(
         "-u",
         "--error-unimportable",
@@ -52,7 +54,7 @@ def main(argv=None):
     if callable(other_parser):
         other_parser = other_parser()
     if args.prog:
-        other_parser.prog = args.prog        
+        other_parser.prog = args.prog
     print(
         complete(
             other_parser,

--- a/shtab/main.py
+++ b/shtab/main.py
@@ -24,6 +24,7 @@ def get_main_parser():
         "--prefix", help="prepended to generated functions to avoid clashes"
     )
     parser.add_argument("--preamble", help="prepended to generated script")
+    parser.add_argument("--prog", help="custom program name (do not use parser.prog)")
     parser.add_argument(
         "-u",
         "--error-unimportable",
@@ -50,6 +51,8 @@ def main(argv=None):
     other_parser = getattr(module, other_parser)
     if callable(other_parser):
         other_parser = other_parser()
+    if args.prog:
+        other_parser.prog = args.prog        
     print(
         complete(
             other_parser,


### PR DESCRIPTION
Ofen my scripts do not contain `parser = ArgumentParser(prog="somenone")` and this will result in strange names in the generated complete script. This change adds an option for these situations.