### PR TITLE
search curdir for modules

### DIFF
--- a/shtab/main.py
+++ b/shtab/main.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, print_function
 
 import argparse
 import logging
+import os
+import sys
 from importlib import import_module
 
 from . import __version__, complete
@@ -43,6 +45,8 @@ def main(argv=None):
     log.debug(args)
 
     module, other_parser = args.parser.rsplit(".", 1)
+    if sys.path and sys.path[0]:  # not blank so not searching curdir
+        sys.path.insert(1, os.curdir)
     try:
         module = import_module(module)
     except ImportError as err:


### PR DESCRIPTION
Removes needing to alter `PYTHONPATH` to expose scripts/packages in the current working directory

- fixes #12

```bash
$ ls
script.py
$ shtab -u script.parser > script_completion.sh
...
ModuleNotFoundError: No module named 'script'
$ PYTHONPATH=. shtab -u script.parser > script_completion.sh  # works
$ pip install -U 'git+https://github.com/iterative/shtab@545b03c#egg=shtab'  # this PR
$ shtab -u script.parser > script_completion.sh  # works
```