### PR TITLE
next release v1.3.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Most of the magic lives in [`shtab/__init__.py`](./shtab/__init__.py).
     - `complete_bash()`
     - `complete_zsh()`
     - ...
-    - `Optional()`, `Required()`, `Choice()` - helpers for advanced completion
-      (e.g. dirs, files, `*.txt`)
+    - `add_argument_to()` - convenience function for library integration
+    - `Optional()`, `Required()`, `Choice()` - legacy helpers for advanced completion (e.g. dirs, files, `*.txt`)
   - [`main.py`](./shtab/main.py)
     - `get_main_parser()` - returns `shtab`'s own parser object
     - `main()` - `shtab`'s own CLI application

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Most of the magic lives in [`shtab/__init__.py`](./shtab/__init__.py).
 
 Given that the number of completions a program may need would likely be less
 than a million, the focus is on readability rather than premature speed
-optimisations.
+optimisations. The generated code itself, on the other had, should be fast.
 
 Helper functions such as `replace_format` allows use of curly braces `{}` in
 string snippets without clashing between python's `str.format` and shell

--- a/README.rst
+++ b/README.rst
@@ -224,12 +224,7 @@ Add direct support to scripts for a little more configurability:
 
     def get_main_parser():
         parser = argparse.ArgumentParser(prog="pathcomplete")
-        parser.add_argument(
-            "-s",
-            "--print-completion-shell",
-            choices=shtab.SUPPORTED_SHELLS,
-            help="prints completion script",
-        )
+        shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
         # file & directory tab complete
         parser.add_argument("file", nargs="?").complete = shtab.FILE
         parser.add_argument("--dir", default=".").complete = shtab.DIRECTORY
@@ -262,8 +257,6 @@ object from `docopt <https://pypi.org/project/docopt>`_ syntax:
 
     Options:
       -g, --goodbye  : Say "goodbye" (instead of "hello")
-      -b, --print-bash-completion  : Output a bash tab-completion script
-      -z, --print-zsh-completion  : Output a zsh tab-completion script
 
     Arguments:
       <you>  : Your name [default: Anon]
@@ -272,15 +265,9 @@ object from `docopt <https://pypi.org/project/docopt>`_ syntax:
     import sys, argopt, shtab  # NOQA
 
     parser = argopt.argopt(__doc__)
+    shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
     if __name__ == "__main__":
         args = parser.parse_args()
-        if args.print_bash_completion:
-            print(shtab.complete(parser, shell="bash"))
-            sys.exit(0)
-        if args.print_zsh_completion:
-            print(shtab.complete(parser, shell="zsh"))
-            sys.exit(0)
-
         msg = "k thx bai!" if args.goodbye else "hai!"
         print("{} says '{}' to {}".format(args.me, msg, args.you))
 

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,22 @@ First run ``brew install bash-completion``, then add the following to
 Usage
 -----
 
+There are two ways of using ``shtab``:
+
+- `CLI Usage`_: ``shtab``'s own CLI interface for external applications
+
+  - may not require any code modifications whatsoever
+  - end-users execute ``shtab your_cli_app.your_parser_object``
+
+- `Library Usage`_: as a library integrated into your CLI application
+
+  - adds a couple of lines to your application
+  - argument mode: end-users execute ``your_cli_app --print-completion-shell {bash,zsh}``
+  - subparser mode: end-users execute ``your_cli_app completion {bash,zsh}``
+
+CLI Usage
+---------
+
 The only requirement is that external CLI applications provide an importable
 ``argparse.ArgumentParser`` object (or alternatively an importable function
 which returns a parser object). This may require a trivial code change.
@@ -203,18 +219,23 @@ appropriate (e.g. ``$CONDA_PREFIX/etc/conda/activate.d/env_vars.sh``).
 By default, ``shtab`` will silently do nothing if it cannot import the requested
 application. Use ``-u, --error-unimportable`` to noisily complain.
 
-Advanced Configuration
-----------------------
+Library Usage
+-------------
 
 See the `examples/ <https://github.com/iterative/shtab/tree/master/examples>`_
 folder for more.
 
 Complex projects with subparsers and custom completions for paths matching
 certain patterns (e.g. ``--file=*.txt``) are fully supported (see
+`examples/customcomplete.py <https://github.com/iterative/shtab/tree/master/examples/customcomplete.py>`_
+or even
 `iterative/dvc:command/completion.py <https://github.com/iterative/dvc/blob/master/dvc/command/completion.py>`_
 for example).
 
 Add direct support to scripts for a little more configurability:
+
+argparse
+~~~~~~~~
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -254,13 +254,7 @@ argparse
     if __name__ == "__main__":
         parser = get_main_parser()
         args = parser.parse_args()
-
-        # completion magic
-        shell = args.print_completion_shell
-        if shell:
-            print(shtab.complete(parser, shell=shell))
-        else:
-            print("received <file>=%r --dir=%r" % (args.file, args.dir))
+        print("received <file>=%r --dir=%r" % (args.file, args.dir))
 
 docopt
 ~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -227,7 +227,7 @@ Add direct support to scripts for a little more configurability:
         parser.add_argument(
             "-s",
             "--print-completion-shell",
-            choices=["bash", "zsh"],
+            choices=shtab.SUPPORTED_SHELLS,
             help="prints completion script",
         )
         # file & directory tab complete

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ There are two ways of using ``shtab``:
 - `Library Usage`_: as a library integrated into your CLI application
 
   - adds a couple of lines to your application
-  - argument mode: end-users execute ``your_cli_app --print-completion-shell {bash,zsh}``
+  - argument mode: end-users execute ``your_cli_app --print-completion {bash,zsh}``
   - subparser mode: end-users execute ``your_cli_app completion {bash,zsh}``
 
 CLI Usage
@@ -245,7 +245,7 @@ argparse
 
     def get_main_parser():
         parser = argparse.ArgumentParser(prog="pathcomplete")
-        shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
+        shtab.add_argument_to(parser, ["-s", "--print-completion"])  # magic!
         # file & directory tab complete
         parser.add_argument("file", nargs="?").complete = shtab.FILE
         parser.add_argument("--dir", default=".").complete = shtab.DIRECTORY
@@ -286,7 +286,7 @@ object from `docopt <https://pypi.org/project/docopt>`_ syntax:
     import sys, argopt, shtab  # NOQA
 
     parser = argopt.argopt(__doc__)
-    shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
+    shtab.add_argument_to(parser, ["-s", "--print-completion"])  # magic!
     if __name__ == "__main__":
         args = parser.parse_args()
         msg = "k thx bai!" if args.goodbye else "hai!"

--- a/examples/customcomplete.py
+++ b/examples/customcomplete.py
@@ -30,7 +30,7 @@ def get_main_parser():
     parser.add_argument(
         "-s",
         "--print-completion-shell",
-        choices=["bash", "zsh"],
+        choices=shtab.SUPPORTED_SHELLS,
         help="prints completion script",
     )
     # `*.txt` file tab completion

--- a/examples/customcomplete.py
+++ b/examples/customcomplete.py
@@ -27,12 +27,7 @@ _shtab_greeter_compgen_TXTFiles() {
 
 def get_main_parser():
     parser = argparse.ArgumentParser(prog="customcomplete")
-    parser.add_argument(
-        "-s",
-        "--print-completion-shell",
-        choices=shtab.SUPPORTED_SHELLS,
-        help="prints completion script",
-    )
+    shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
     # `*.txt` file tab completion
     parser.add_argument("input_txt", nargs="?").complete = TXT_FILE
     # file tab completion builtin shortcut
@@ -51,14 +46,7 @@ def get_main_parser():
 if __name__ == "__main__":
     parser = get_main_parser()
     args = parser.parse_args()
-
-    # completion magic
-    shell = args.print_completion_shell
-    if shell:
-        script = shtab.complete(parser, shell=shell, preamble=PREAMBLE)
-        print(script)
-    else:
-        print(
-            "received <input_txt>=%r --output-dir=%r --output-name=%r"
-            % (args.input_txt, args.output_dir, args.output_name)
-        )
+    print(
+        "received <input_txt>=%r --input-file=%r --output-name=%r"
+        % (args.input_txt, args.input_file, args.output_name)
+    )

--- a/examples/customcomplete.py
+++ b/examples/customcomplete.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-`argparse`-based CLI app with custom file completion.
+`argparse`-based CLI app with custom file completion as well as subparsers.
 
 See `pathcomplete.py` for a more basic version.
 """
@@ -26,8 +26,13 @@ _shtab_greeter_compgen_TXTFiles() {
 
 
 def get_main_parser():
-    parser = argparse.ArgumentParser(prog="customcomplete")
-    shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
+    main_parser = argparse.ArgumentParser(prog="customcomplete")
+    subparsers = main_parser.add_subparsers()
+
+    parser = subparsers.add_parser("completion")
+    shtab.add_argument_to(parser, "shell")  # magic!
+
+    parser = subparsers.add_parser("process")
     # `*.txt` file tab completion
     parser.add_argument("input_txt", nargs="?").complete = TXT_FILE
     # file tab completion builtin shortcut
@@ -40,7 +45,7 @@ def get_main_parser():
             " accidentally overwriting existing files."
         ),
     ).complete = shtab.DIRECTORY  # directory tab completion builtin shortcut
-    return parser
+    return main_parser
 
 
 if __name__ == "__main__":

--- a/examples/customcomplete.py
+++ b/examples/customcomplete.py
@@ -5,8 +5,6 @@
 See `pathcomplete.py` for a more basic version.
 """
 import argparse
-import functools
-import sys
 
 import shtab  # for completion magic
 
@@ -36,13 +34,10 @@ def process(args):
 
 def get_main_parser():
     main_parser = argparse.ArgumentParser(prog="customcomplete")
-    add_subparsers = functools.partial(
-        main_parser.add_subparsers, dest="subcommand"
-    )
-    if sys.version_info[:2] >= (3, 7):
-        subparsers = add_subparsers(required=True)
-    else:
-        subparsers = add_subparsers()
+    subparsers = main_parser.add_subparsers()
+    # make required (py3.7 API change); vis. https://bugs.python.org/issue16308
+    subparsers.required = True
+    subparsers.dest = "subcommand"
 
     parser = subparsers.add_parser("completion")
     shtab.add_argument_to(parser, "shell")  # magic!

--- a/examples/customcomplete.py
+++ b/examples/customcomplete.py
@@ -5,6 +5,8 @@
 See `pathcomplete.py` for a more basic version.
 """
 import argparse
+import functools
+import sys
 
 import shtab  # for completion magic
 
@@ -25,9 +27,22 @@ _shtab_greeter_compgen_TXTFiles() {
 }
 
 
+def process(args):
+    print(
+        "received <input_txt>=%r --input-file=%r --output-name=%r"
+        % (args.input_txt, args.input_file, args.output_name)
+    )
+
+
 def get_main_parser():
     main_parser = argparse.ArgumentParser(prog="customcomplete")
-    subparsers = main_parser.add_subparsers()
+    add_subparsers = functools.partial(
+        main_parser.add_subparsers, dest="subcommand"
+    )
+    if sys.version_info[:2] >= (3, 7):
+        subparsers = add_subparsers(required=True)
+    else:
+        subparsers = add_subparsers()
 
     parser = subparsers.add_parser("completion")
     shtab.add_argument_to(parser, "shell")  # magic!
@@ -45,13 +60,11 @@ def get_main_parser():
             " accidentally overwriting existing files."
         ),
     ).complete = shtab.DIRECTORY  # directory tab completion builtin shortcut
+    parser.set_defaults(func=process)
     return main_parser
 
 
 if __name__ == "__main__":
     parser = get_main_parser()
     args = parser.parse_args()
-    print(
-        "received <input_txt>=%r --input-file=%r --output-name=%r"
-        % (args.input_txt, args.input_file, args.output_name)
-    )
+    args.func(args)

--- a/examples/docopt-greeter.py
+++ b/examples/docopt-greeter.py
@@ -6,8 +6,6 @@ Usage:
 
 Options:
   -g, --goodbye  : Say "goodbye" (instead of "hello")
-  -b, --print-bash-completion  : Output a bash tab-completion script
-  -z, --print-zsh-completion  : Output a zsh tab-completion script
 
 Arguments:
   <you>  : Your name [default: Anon]
@@ -16,14 +14,9 @@ Arguments:
 import sys, argopt, shtab  # NOQA
 
 parser = argopt.argopt(__doc__)
+shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
 if __name__ == "__main__":
     args = parser.parse_args()
-    if args.print_bash_completion:
-        print(shtab.complete(parser, shell="bash"))
-        sys.exit(0)
-    if args.print_zsh_completion:
-        print(shtab.complete(parser, shell="zsh"))
-        sys.exit(0)
 
     msg = "k thx bai!" if args.goodbye else "hai!"
     print("{} says '{}' to {}".format(args.me, msg, args.you))

--- a/examples/docopt-greeter.py
+++ b/examples/docopt-greeter.py
@@ -14,7 +14,7 @@ Arguments:
 import sys, argopt, shtab  # NOQA
 
 parser = argopt.argopt(__doc__)
-shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
+shtab.add_argument_to(parser, ["-s", "--print-completion"])  # magic!
 if __name__ == "__main__":
     args = parser.parse_args()
 

--- a/examples/pathcomplete.py
+++ b/examples/pathcomplete.py
@@ -12,12 +12,7 @@ import shtab  # for completion magic
 
 def get_main_parser():
     parser = argparse.ArgumentParser(prog="pathcomplete")
-    parser.add_argument(
-        "-s",
-        "--print-completion-shell",
-        choices=shtab.SUPPORTED_SHELLS,
-        help="prints completion script",
-    )
+    shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
     # file & directory tab complete
     parser.add_argument("file", nargs="?").complete = shtab.FILE
     parser.add_argument("--dir", default=".").complete = shtab.DIRECTORY
@@ -27,10 +22,4 @@ def get_main_parser():
 if __name__ == "__main__":
     parser = get_main_parser()
     args = parser.parse_args()
-
-    # completion magic
-    shell = args.print_completion_shell
-    if shell:
-        print(shtab.complete(parser, shell=shell))
-    else:
-        print("received <file>=%r --dir=%r" % (args.file, args.dir))
+    print("received <file>=%r --dir=%r" % (args.file, args.dir))

--- a/examples/pathcomplete.py
+++ b/examples/pathcomplete.py
@@ -15,7 +15,7 @@ def get_main_parser():
     parser.add_argument(
         "-s",
         "--print-completion-shell",
-        choices=["bash", "zsh"],
+        choices=shtab.SUPPORTED_SHELLS,
         help="prints completion script",
     )
     # file & directory tab complete

--- a/examples/pathcomplete.py
+++ b/examples/pathcomplete.py
@@ -12,7 +12,7 @@ import shtab  # for completion magic
 
 def get_main_parser():
     parser = argparse.ArgumentParser(prog="pathcomplete")
-    shtab.add_argument_to(parser, ["-s", "--print-completion-shell"])  # magic!
+    shtab.add_argument_to(parser, ["-s", "--print-completion"])  # magic!
     # file & directory tab complete
     parser.add_argument("file", nargs="?").complete = shtab.FILE
     parser.add_argument("--dir", default=".").complete = shtab.DIRECTORY

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -209,18 +209,16 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
             print("{}='{}'".format(prefix, opts), file=fd)
 
         for sub in positionals:
+            if hasattr(sub, "complete"):
+                print(
+                    "{}_COMPGEN={}".format(
+                        prefix,
+                        complete2pattern(sub.complete, "bash", choice_type2fn),
+                    ),
+                    file=fd,
+                )
             if sub.choices:
                 log.debug("choices:{}:{}".format(prefix, sorted(sub.choices)))
-                if hasattr(sub, "complete"):
-                    print(
-                        "{}_COMPGEN={}".format(
-                            prefix,
-                            complete2pattern(
-                                sub.complete, "bash", choice_type2fn
-                            ),
-                        ),
-                        file=fd,
-                    )
                 for cmd in sorted(sub.choices):
                     if isinstance(cmd, Choice):
                         log.debug(

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -42,6 +42,7 @@ else:
 __all__ = ["Optional", "Required", "Choice", "complete"]
 log = logging.getLogger(__name__)
 
+SUPPORTED_SHELLS = ("bash", "zsh")
 CHOICE_FUNCTIONS = {
     "file": {"bash": "_shtab_compgen_files", "zsh": "_files"},
     "directory": {"bash": "_shtab_compgen_dirs", "zsh": "_files -/"},
@@ -558,11 +559,13 @@ def complete(
     """
     if isinstance(preamble, dict):
         preamble = preamble.get(shell, "")
-    completers = {"bash": complete_bash, "zsh": complete_zsh}
     try:
-        driver = completers[shell]
+        driver = globals()["complete_" + shell]
     except KeyError:
-        raise KeyError("shell must be one of {%s}" % ",".join(completers))
+        raise KeyError(
+            "shell (%s) must be one of {%s}"
+            % (shell, ",".join(SUPPORTED_SHELLS))
+        )
     return driver(
         parser,
         root_prefix=root_prefix,

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -152,6 +152,11 @@ def replace_format(string, **fmt):
     return string
 
 
+def wordify(string):
+    """Replace hyphens (-) and spaces ( ) with underscores (_)"""
+    return string.replace("-", "_").replace(" ", "_")
+
+
 def get_bash_commands(root_parser, root_prefix, choice_functions=None):
     """
     Recursive subcommand parser traversal, printing bash helper syntax.
@@ -237,8 +242,7 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                         if sub.choices[cmd].add_help:
                             commands.append(cmd)
                             recurse(
-                                sub.choices[cmd],
-                                prefix + "_" + cmd.replace("-", "_"),
+                                sub.choices[cmd], prefix + "_" + wordify(cmd),
                             )
                         else:
                             log.debug("skip:subcommand:%s", cmd)
@@ -263,7 +267,7 @@ def complete_bash(
 
     See `complete` for arguments.
     """
-    root_prefix = "_shtab_" + (root_prefix or parser.prog)
+    root_prefix = wordify("_shtab_" + (root_prefix or parser.prog))
     commands, options, subcommands_script = get_bash_commands(
         parser, root_prefix, choice_functions=choice_functions
     )
@@ -383,8 +387,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
 
     See `complete` for arguments.
     """
-    root_prefix = "_shtab_" + (root_prefix or parser.prog)
-
+    root_prefix = wordify("_shtab_" + (root_prefix or parser.prog))
     root_arguments = []
     subcommands = {}  # {cmd: {"help": help, "arguments": [arguments]}}
 
@@ -546,9 +549,7 @@ esac""",
         ),
         commands_case="\n  ".join(
             "{cmd_orig}) _arguments ${root_prefix}_{cmd} ;;".format(
-                cmd_orig=cmd,
-                cmd=cmd.replace("-", "_"),
-                root_prefix=root_prefix,
+                cmd_orig=cmd, cmd=wordify(cmd), root_prefix=root_prefix,
             )
             for cmd in sorted(subcommands)
         ),
@@ -558,7 +559,7 @@ esac""",
   {arguments}
 )""".format(
                 root_prefix=root_prefix,
-                cmd=cmd.replace("-", "_"),
+                cmd=wordify(cmd),
                 arguments="\n  ".join(subcommands[cmd]["arguments"]),
             )
             for cmd in sorted(subcommands)

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -564,9 +564,8 @@ def complete(
     try:
         driver = globals()["complete_" + shell]
     except KeyError:
-        raise KeyError(
-            "shell (%s) must be one of {%s}"
-            % (shell, ",".join(SUPPORTED_SHELLS))
+        raise NotImplementedError(
+            "shell (%s) must be in {%s}" % (shell, ",".join(SUPPORTED_SHELLS))
         )
     return driver(
         parser,
@@ -574,7 +573,6 @@ def complete(
         preamble=preamble,
         choice_functions=choice_functions,
     )
-    raise NotImplementedError(shell)
 
 
 class PrintCompletionAction(Action):

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -206,12 +206,12 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
             opts += get_optional_actions(parser)
             # use list rather than set to maintain order
             opts = " ".join(opts)
-            print("{}='{}'".format(prefix, opts), file=fd)
+            print(u"{}='{}'".format(prefix, opts), file=fd)
 
         for sub in positionals:
             if hasattr(sub, "complete"):
                 print(
-                    "{}_COMPGEN={}".format(
+                    u"{}_COMPGEN={}".format(
                         prefix,
                         complete2pattern(sub.complete, "bash", choice_type2fn),
                     ),
@@ -227,7 +227,7 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                             )
                         )
                         print(
-                            "{}_COMPGEN={}".format(
+                            u"{}_COMPGEN={}".format(
                                 prefix, choice_type2fn[cmd.type]
                             ),
                             file=fd,

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -3,8 +3,10 @@ from __future__ import print_function
 import io
 import logging
 import re
+import sys
 from argparse import (
     SUPPRESS,
+    Action,
     _AppendAction,
     _AppendConstAction,
     _CountAction,
@@ -573,3 +575,33 @@ def complete(
         choice_functions=choice_functions,
     )
     raise NotImplementedError(shell)
+
+
+class PrintCompletionAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(complete(parser, values))
+        parser.exit(0)
+
+
+def add_argument_to(
+    parser,
+    option_string="--print-completion-shell",
+    help="print shell completion script",
+):
+    """
+    parser  : argparse.ArgumentParser
+    option_string  : str or list[str]
+    help  : str
+    """
+    if isinstance(
+        option_string, str if sys.version_info[0] > 2 else basestring  # NOQA
+    ):
+        option_string = [option_string]
+    kwargs = dict(
+        choices=SUPPORTED_SHELLS,
+        default=None,
+        help=help,
+        action=PrintCompletionAction,
+    )
+    parser.add_argument(*option_string, **kwargs)
+    return parser

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -590,8 +590,8 @@ def complete(
     """
     if isinstance(preamble, dict):
         preamble = preamble.get(shell, "")
-    driver = get_completer(shell)
-    return driver(
+    completer = get_completer(shell)
+    return completer(
         parser,
         root_prefix=root_prefix,
         preamble=preamble,

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -558,18 +558,15 @@ def complete(
     """
     if isinstance(preamble, dict):
         preamble = preamble.get(shell, "")
-    if shell == "bash":
-        return complete_bash(
-            parser,
-            root_prefix=root_prefix,
-            preamble=preamble,
-            choice_functions=choice_functions,
-        )
-    if shell == "zsh":
-        return complete_zsh(
-            parser,
-            root_prefix=root_prefix,
-            preamble=preamble,
-            choice_functions=choice_functions,
-        )
+    completers = {"bash": complete_bash, "zsh": complete_zsh}
+    try:
+        driver = completers[shell]
+    except KeyError:
+        raise KeyError("shell must be one of {%s}" % ",".join(completers))
+    return driver(
+        parser,
+        root_prefix=root_prefix,
+        preamble=preamble,
+        choice_functions=choice_functions,
+    )
     raise NotImplementedError(shell)

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -607,7 +607,7 @@ class PrintCompletionAction(Action):
 
 def add_argument_to(
     parser,
-    option_string="--print-completion-shell",
+    option_string="--print-completion",
     help="print shell completion script",
 ):
     """

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -588,7 +588,8 @@ def add_argument_to(
 ):
     """
     parser  : argparse.ArgumentParser
-    option_string  : str or list[str]
+    option_string  : str or list[str], iff positional (no `-` prefix) then
+      `parser` is assumed to actually be a subparser (subcommand mode)
     help  : str
     """
     if isinstance(
@@ -601,5 +602,7 @@ def add_argument_to(
         help=help,
         action=PrintCompletionAction,
     )
+    if option_string[0][0] != "-":  # subparser mode
+        kwargs.update(default=SUPPORTED_SHELLS[0], nargs="?")
     parser.add_argument(*option_string, **kwargs)
     return parser

--- a/shtab/main.py
+++ b/shtab/main.py
@@ -6,7 +6,7 @@ import os
 import sys
 from importlib import import_module
 
-from . import __version__, complete
+from . import SUPPORTED_SHELLS, __version__, complete
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ def get_main_parser():
         "--version", action="version", version="%(prog)s " + __version__
     )
     parser.add_argument(
-        "-s", "--shell", default="bash", choices=["bash", "zsh"]
+        "-s", "--shell", default=SUPPORTED_SHELLS[0], choices=SUPPORTED_SHELLS
     )
     parser.add_argument(
         "--prefix", help="prepended to generated functions to avoid clashes"

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -174,6 +174,39 @@ def test_subparser_custom_complete(shell, caplog):
 
 
 @fix_shell
+def test_add_argument_to_optional(shell, caplog):
+    parser = ArgumentParser(prog="test")
+    shtab.add_argument_to(parser, ["-s", "--shell"])
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell=shell)
+    print(completion)
+
+    if shell == "bash":
+        shell = Bash(completion)
+        shell.compgen('-W "$_shtab_test_options_"', "--s", "--shell")
+
+    assert not caplog.record_tuples
+
+
+@fix_shell
+def test_add_argument_to_positional(shell, caplog):
+    parser = ArgumentParser(prog="test")
+    subparsers = parser.add_subparsers()
+    sub = subparsers.add_parser("completion")
+    shtab.add_argument_to(sub, "shell")
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell=shell)
+    print(completion)
+
+    if shell == "bash":
+        shell = Bash(completion)
+        shell.compgen('-W "$_shtab_test_completion"', "ba", "bash")
+        shell.compgen('-W "$_shtab_test_completion"', "z", "zsh")
+
+    assert not caplog.record_tuples
+
+
+@fix_shell
 def test_get_completer(shell):
     shtab.get_completer(shell)
 

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -132,3 +132,12 @@ def test_positional_choices(shell, caplog):
         shell.compgen('-W "$_shtab_test_commands_"', "o", "one")
 
     assert not caplog.record_tuples
+
+
+def test_get_completer():
+    try:
+        shtab.get_completer("invalid")
+    except NotImplementedError:
+        pass
+    else:
+        raise NotImplementedError("invalid")

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -173,7 +173,12 @@ def test_subparser_custom_complete(shell, caplog):
     assert not caplog.record_tuples
 
 
-def test_get_completer():
+@fix_shell
+def test_get_completer(shell):
+    shtab.get_completer(shell)
+
+
+def test_get_completer_invalid():
     try:
         shtab.get_completer("invalid")
     except NotImplementedError:

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -13,8 +13,7 @@ import pytest
 import shtab
 from shtab.main import get_main_parser, main
 
-SUPPORTED_SHELLS = "bash", "zsh"
-fix_shell = pytest.mark.parametrize("shell", SUPPORTED_SHELLS)
+fix_shell = pytest.mark.parametrize("shell", shtab.SUPPORTED_SHELLS)
 
 
 class Bash(object):


### PR DESCRIPTION
- fix bash missing custom complete functionality (`add_argument().complete = ...`)
- fix subcommand completion & update `examples/customcomplete.py`
- expose `SUPPORTED_SHELLS`
- add `shtab.add_argument_to(parser, option_string)` (#18)
  + option: adds `your_cli_app [--print-completion={bash,zsh}]`
  + subcommand: adds `your_cli_app completion [{bash,zsh}]`
  + handles the `print(shtab.complete(parser, shell))` & `exit(0)` logic too
- misc tidy
- add & update documentation
- [x] add tests

---

- fixes #18