### PR TITLE
next release v1.3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - run: pip install -U -r requirements-dev.txt
-    - run: python -m tests
+    - run: python -m tests --cov-report=term-missing
     - uses: codecov/codecov-action@v1
   deploy:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -153,8 +153,8 @@ def replace_format(string, **fmt):
 
 
 def wordify(string):
-    """Replace hyphens (-) and spaces ( ) with underscores (_)"""
-    return string.replace("-", "_").replace(" ", "_")
+    """Replace non-word chars [-. ] with underscores [_]"""
+    return string.replace("-", "_").replace(".", " ").replace(" ", "_")
 
 
 def get_bash_commands(root_parser, root_prefix, choice_functions=None):

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -5,8 +5,9 @@ from subprocess import check_call
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 check_call(
     (
-        "py.test -v --log-level=debug --cov=shtab --cov-report=xml"
-        " {params} --durations=0".format(params=" ".join(sys.argv[1:]))
+        "py.test -v --log-level=debug --cov=shtab"
+        " --cov-report=xml --cov-report=term-missing --durations=0"
+        + (" ".join([""] + sys.argv[1:]))
     ),
     shell=True,
     env=dict(os.environ, PYTHONPATH=REPO_ROOT),

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -92,6 +92,31 @@ def test_prog_override(shell, caplog, capsys):
 
 
 @fix_shell
+def test_prog_scripts(shell, caplog, capsys):
+    with caplog.at_level(logging.INFO):
+        main(
+            ["-s", shell, "--prog", "script.py", "shtab.main.get_main_parser"]
+        )
+
+    captured = capsys.readouterr()
+    assert not captured.err
+    script_py = [
+        i.strip() for i in captured.out.splitlines() if "script.py" in i
+    ]
+    if shell == "bash":
+        assert script_py == ["complete -o nospace -F _shtab_shtab script.py"]
+    elif shell == "zsh":
+        assert script_py == [
+            "#compdef script.py",
+            "_describe 'script.py commands' _commands",
+        ]
+    else:
+        raise NotImplementedError(shell)
+
+    assert not caplog.record_tuples
+
+
+@fix_shell
 def test_prefix_override(shell, caplog, capsys):
     with caplog.at_level(logging.INFO):
         main(["-s", shell, "--prefix", "foo", "shtab.main.get_main_parser"])


### PR DESCRIPTION
- allow periods in script names (#20)
  + [x] support e.g. `script.py` (not just console entrypoints such as `script`)
  + [x] support e.g. `./script.py` (explicit local path)
    * [x] ~~maybe add `sys.argv[0]`?~~
  + [x] test
- coverage reporting by default for tests

---

- fixes #20