### PR TITLE
fix bash>=4.4 bad substitution

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -304,6 +304,11 @@ _shtab_replace_hyphen() {
 }
 
 # $1=COMP_WORDS[1]
+_shtab_replace_nonword() {
+  echo "${1//[^[:word:]]/_}"
+}
+
+# $1=COMP_WORDS[1]
 {root_prefix}_compgen_root_() {
   local args_gen="{root_prefix}_COMPGEN"
   case "$word" in
@@ -316,7 +321,7 @@ _shtab_replace_hyphen() {
 
 # $1=COMP_WORDS[1]
 {root_prefix}_compgen_command_() {
-  local flags_list="{root_prefix}_$(_shtab_replace_hyphen $1)"
+  local flags_list="{root_prefix}_$(_shtab_replace_nonword $1)"
   local args_gen="${flags_list}_COMPGEN"
   COMPREPLY=( $(compgen -W "${!flags_list}" -- "$word"; \
 [ -n "${!args_gen}" ] && ${!args_gen} "$word") )
@@ -325,8 +330,7 @@ _shtab_replace_hyphen() {
 # $1=COMP_WORDS[1]
 # $2=COMP_WORDS[2]
 {root_prefix}_compgen_subcommand_() {
-  local flags_list="{root_prefix}_$(\
-_shtab_replace_hyphen $1)_$(_shtab_replace_hyphen $2)"
+  local flags_list="{root_prefix}_$(_shtab_replace_nonword "${1}_${2}")"
   local args_gen="${flags_list}_COMPGEN"
   [ -n "${!args_gen}" ] && local opts_more="$(${!args_gen} "$word")"
   local opts="${!flags_list}"


### PR DESCRIPTION
- fixes #22

locally tested using docker `bash:4.4`.

Fixes the bash>=4.4 error:

```bash
x=a/b
echo ${!a}  # bash<=4.3: empty, >=4.4: error bash substitution
```

There's no real documentation about this change. Vaguely related links:

- https://stackoverflow.com/questions/20615217/bash-bad-substitution
- https://github.com/bminor/bash/blob/bash-4.4-testing/CHANGES
