### PR TITLE
fix potential parser help str casting error

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -358,7 +358,7 @@ complete -o filenames -F {root_prefix} {prog}""",
 
 
 def escape_zsh(string):
-    return RE_ZSH_SPECIAL_CHARS.sub(r"\\\1", string)
+    return RE_ZSH_SPECIAL_CHARS.sub(r"\\\1", str(string))
 
 
 @mark_completer("zsh")


### PR DESCRIPTION
Sometimes `add_argument(help=...)` is not a string (but is castable to a string).

----

- fixes #41