### PR TITLE
Determine whether to add a subparser to completion by its presence in `_get_subactions()`

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -143,10 +143,6 @@ def wordify(string):
 
 def get_public_subcommands(sub):
     """Get all the publicly-visible subcommands for a given subparser."""
-    # NOTE: public subcommands have their primary name listed in the result of
-    # `_get_subactions()`. We use this to get the parser for each subcommand and
-    # compare all the choices (including aliases!) to the set of known-public
-    # parsers.
     public_parsers = {id(sub.choices[i.dest]) for i in sub._get_subactions()}
     return {k for k, v in sub.choices.items() if id(v) in public_parsers}
 
@@ -214,9 +210,6 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                 # choices (including subparsers & shtab `.complete` functions)
                 log.debug("choices:{}:{}".format(prefix, sorted(positional.choices)))
 
-                if isinstance(positional.choices, dict):
-                    public_cmds = get_public_subcommands(positional)
-
                 this_positional_choices = []
                 for choice in positional.choices:
                     if isinstance(choice, Choice):
@@ -235,6 +228,7 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                     elif isinstance(positional.choices, dict):
                         # subparser, so append to list of subparsers & recurse
                         log.debug("subcommand:%s", choice)
+                        public_cmds = get_public_subcommands(positional)
                         if choice in public_cmds:
                             discovered_subparsers.append(str(choice))
                             this_positional_choices.append(str(choice))

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -3,6 +3,7 @@ Tests for `shtab`.
 """
 import logging
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 import pytest
@@ -195,6 +196,7 @@ def test_subparser_custom_complete(shell, caplog):
 
 
 @fix_shell
+@pytest.mark.skipif(sys.version_info[0] == 2, reason="requires Python 3.x")
 def test_subparser_aliases(shell, caplog):
     parser = ArgumentParser(prog="test")
     subparsers = parser.add_subparsers()

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -177,7 +177,7 @@ def test_custom_complete(shell, caplog):
 def test_subparser_custom_complete(shell, caplog):
     parser = ArgumentParser(prog="test")
     subparsers = parser.add_subparsers()
-    sub = subparsers.add_parser("sub")
+    sub = subparsers.add_parser("sub", help="help message")
     sub.add_argument("posA").complete = {"bash": "_shtab_test_some_func"}
     preamble = {"bash": "_shtab_test_some_func() { compgen -W 'one two' -- $1 ;}"}
     with caplog.at_level(logging.INFO):
@@ -188,6 +188,31 @@ def test_subparser_custom_complete(shell, caplog):
         shell = Bash(completion)
         shell.compgen('-W "${_shtab_test_subparsers[*]}"', "s", "sub")
         shell.compgen('-W "$_shtab_test_pos_0_choices"', "s", "sub")
+        shell.test('"$($_shtab_test_sub_pos_0_COMPGEN o)" = "one"')
+        shell.test('-z "$_shtab_test_COMPGEN"')
+
+    assert not caplog.record_tuples
+
+
+@fix_shell
+def test_subparser_aliases(shell, caplog):
+    parser = ArgumentParser(prog="test")
+    subparsers = parser.add_subparsers()
+    sub = subparsers.add_parser("sub", aliases=["xsub", "ysub"], help="help message")
+    sub.add_argument("posA").complete = {"bash": "_shtab_test_some_func"}
+    preamble = {"bash": "_shtab_test_some_func() { compgen -W 'one two' -- $1 ;}"}
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell=shell, preamble=preamble)
+    print(completion)
+
+    if shell == "bash":
+        shell = Bash(completion)
+        shell.compgen('-W "${_shtab_test_subparsers[*]}"', "s", "sub")
+        shell.compgen('-W "$_shtab_test_pos_0_choices"', "s", "sub")
+        shell.compgen('-W "${_shtab_test_subparsers[*]}"', "x", "xsub")
+        shell.compgen('-W "$_shtab_test_pos_0_choices"', "x", "xsub")
+        shell.compgen('-W "${_shtab_test_subparsers[*]}"', "y", "ysub")
+        shell.compgen('-W "$_shtab_test_pos_0_choices"', "y", "ysub")
         shell.test('"$($_shtab_test_sub_pos_0_COMPGEN o)" = "one"')
         shell.test('-z "$_shtab_test_COMPGEN"')
 
@@ -213,7 +238,7 @@ def test_add_argument_to_optional(shell, caplog):
 def test_add_argument_to_positional(shell, caplog, capsys):
     parser = ArgumentParser(prog="test")
     subparsers = parser.add_subparsers()
-    sub = subparsers.add_parser("completion")
+    sub = subparsers.add_parser("completion", help="help message")
     shtab.add_argument_to(sub, "shell", parent=parser)
     from argparse import Namespace
 


### PR DESCRIPTION
This is just a small change to the logic for when to generate completion for a subparser. The new logic is the same that `argparse` uses for showing a subparser in the list of options (i.e. if you don't pass `help` to `add_parser`, that subparser is omitted from your program's overall help message).

This is particularly important for subparsers which pass `add_help=False` in order to provide their *own* help implementation. This is something I do in one of my projects. See [here](https://github.com/jimporter/bfg9000/blob/8102fe1c96f86b3afc58bc73da1f449f934f6c1a/bfg9000/driver.py#L315-L318) and [here](https://github.com/jimporter/bfg9000/blob/8102fe1c96f86b3afc58bc73da1f449f934f6c1a/bfg9000/driver.py#L145-L146) for an example.

Note: this is a breaking change, since now subparsers with no `help` kwarg will no longer have shell-completion generated for them. I think this is the correct behavior though, and fixing this is easy enough for users of shtab: just set `help` to something like `None` or `''` (or even better, add an actual help message!).