### PR TITLE
Initial type hints support

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+warn_unused_configs = True
+warn_unused_ignores = True
+show_error_codes = True
+
+# setuptools_scm has no type hints
+[mypy-setuptools_scm]
+ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pytest-timeout
+mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,8 @@ packages=find:
 [options.entry_points]
 console_scripts=
     shtab=shtab.main:main
+[options.package_data]
+shtab=py.typed
 [options.packages.find]
 exclude=docs,tests
 [bdist_wheel]

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -3,9 +3,11 @@ from __future__ import print_function
 import logging
 import re
 import sys
+import typing as t
 from argparse import (
     SUPPRESS,
     Action,
+    ArgumentParser,
     _AppendAction,
     _AppendConstAction,
     _CountAction,
@@ -30,9 +32,9 @@ except ImportError:
 __all__ = ["complete", "add_argument_to", "SUPPORTED_SHELLS", "FILE", "DIRECTORY", "DIR"]
 log = logging.getLogger(__name__)
 
-SUPPORTED_SHELLS = []
+SUPPORTED_SHELLS: t.List[str] = []
 _SUPPORTED_COMPLETERS = {}
-CHOICE_FUNCTIONS = {
+CHOICE_FUNCTIONS: t.Dict[str, t.Dict[str, str]] = {
     "file": {"bash": "_shtab_compgen_files", "zsh": "_files", "tcsh": "f"},
     "directory": {"bash": "_shtab_compgen_dirs", "zsh": "_files -/", "tcsh": "d"}}
 FILE = CHOICE_FUNCTIONS["file"]
@@ -74,7 +76,7 @@ class Choice(object):
 
     >>> ArgumentParser.add_argument(..., choices=[Choice("<type>")])
     """
-    def __init__(self, choice_type, required=False):
+    def __init__(self, choice_type: str, required: bool = False) -> None:
         """
         See below for parameters.
 
@@ -84,18 +86,18 @@ class Choice(object):
         self.required = required
         self.type = choice_type
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.type + ("" if self.required else "?")
 
-    def __cmp__(self, other):
+    def __cmp__(self, other: object) -> int:
         if self.required:
             return 0 if other else -1
         return 0
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return self.__cmp__(other) == 0
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         return self.__cmp__(other) < 0
 
 
@@ -113,12 +115,12 @@ class Required(object):
     DIR = DIRECTORY = [Choice("directory", True)]
 
 
-def complete2pattern(opt_complete, shell, choice_type2fn):
+def complete2pattern(opt_complete, shell, choice_type2fn) -> bool:
     return (opt_complete.get(shell, "")
             if isinstance(opt_complete, dict) else choice_type2fn[opt_complete])
 
 
-def wordify(string):
+def wordify(string: str) -> str:
     """Replace non-word chars [-. ] with underscores [_]"""
     return string.replace("-", "_").replace(".", " ").replace(" ", "_")
 
@@ -685,15 +687,16 @@ complete ${prog} \\
         optionals_special_str=' \\\n        '.join(specials))
 
 
-def complete(parser, shell="bash", root_prefix=None, preamble="", choice_functions=None):
+def complete(parser: ArgumentParser, shell: str = "bash", root_prefix: t.Optional[str] = None,
+             preamble: str = "", choice_functions: t.Optional[t.Any] = None) -> str:
     """
     parser  : argparse.ArgumentParser
     shell  : str (bash/zsh)
-    root_prefix  : str
+    root_prefix  : str or `None`
       prefix for shell functions to avoid clashes (default: "_{parser.prog}")
-    preamble  : dict
-      mapping shell to text to prepend to generated script
-      (e.g. `{"bash": "_myprog_custom_function(){ echo hello }"}`)
+    preamble  : str
+      text to prepend to generated script
+      (e.g. `"_myprog_custom_function(){ echo hello }"`)
     choice_functions  : deprecated
 
     N.B. `parser.add_argument().complete = ...` can be used to define custom

--- a/shtab/py.typed
+++ b/shtab/py.typed
@@ -1,0 +1,2 @@
+This file exists solely to signal that the `shtab` package carries inline types.
+Do not delete it.


### PR DESCRIPTION
Just pushing this up for visibility; I haven't tested this downstream yet.

Some notes:

* I've done `import typing as t` to avoid shadowing `shtab.Optional`. Let me know if you'd prefer another approach (I figured a short `as t` alias is justified to keep the visual noise down.
* I've added a `mypy.ini` file with some reasonable defaults. In particular MyPy is configured to ignore the `setuptools_scm` import, since marking it with `# type: ignore` confuses the combination of `yapf` and `isort`.

Closes #59.