### PR TITLE
fix: skip main command options after subcommands appear

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -557,8 +557,8 @@ local context state line curcontext="$curcontext"
 _arguments \\
   $$${root_prefix}_options_ \\
   ${root_arguments} \\
-  ': :${root_prefix}_commands_' \\
-  '*::args:->args'
+  '(-): :${root_prefix}_commands_' \\
+  '(-)*::args:->args'
 
 case $words[1] in
   ${commands_case}


### PR DESCRIPTION
This commit will skip command options if subcommands appear on the command line. This fixes the scenario where the main command and the subcommand have the same options, and the subcommand cannot be further completed after entering the same options.

Here is the explaination copied from the [zsh manual](https://zsh.sourceforge.io/Doc/Release/Completion-System.html):

> Each of the forms above may be preceded by a list in parentheses of option names and argument numbers. If the given option is on the command line, the options and arguments indicated in parentheses will not be offered. For example, ‘(-two -three 1)-one:...’ completes the option ‘-one’; if this appears on the command line, the options -two and -three and the first ordinary argument will not be completed after it. ‘(-foo):...’ specifies an ordinary argument completion; -foo will not be completed if that argument is already present.
> 
> Other items may appear in the list of excluded options to indicate various other items that should not be applied when the current specification is matched: a single star (*) for the rest arguments (i.e. a specification of the form ‘*:...’); a colon (:) for all normal (non-option-) arguments; **and a hyphen (-) for all options**. For example, if ‘(*)’ appears before an option and the option appears on the command line, the list of remaining arguments (those shown in the above table beginning with ‘*:’) will not be completed.
> 
> To aid in reuse of specifications, it is possible to precede any of the forms above with ‘!’; then the form will no longer be completed, although if the option or argument appears on the command line they will be skipped as normal. The main use for this is when the arguments are given by an array, and _arguments is called repeatedly for more specific contexts: on the first call ‘_arguments $global_options’ is used, and on subsequent calls ‘_arguments !$^global_options’.
