### PR TITLE
Fix subcommands with hyphens (and periods, spaces, etc) in zsh

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -550,13 +550,14 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
     def command_case(prefix, options):
         name = options["cmd"]
         commands = options["commands"]
-        case_fmt_on_no_sub = """{name}) _arguments -C ${prefix}_{name}_options ;;"""
-        case_fmt_on_sub = """{name}) {prefix}_{name} ;;"""
+        case_fmt_on_no_sub = """{name}) _arguments -C ${prefix}_{name_wordify}_options ;;"""
+        case_fmt_on_sub = """{name}) {prefix}_{name_wordify} ;;"""
 
         cases = []
         for _, options in sorted(commands.items()):
             fmt = case_fmt_on_sub if options.get("commands") else case_fmt_on_no_sub
-            cases.append(fmt.format(name=options["cmd"], prefix=prefix))
+            cases.append(
+                fmt.format(name=options["cmd"], name_wordify=wordify(options["cmd"]), prefix=prefix))
         cases = "\n\t".expandtabs(8).join(cases)
 
         return """\

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -557,7 +557,8 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
         for _, options in sorted(commands.items()):
             fmt = case_fmt_on_sub if options.get("commands") else case_fmt_on_no_sub
             cases.append(
-                fmt.format(name=options["cmd"], name_wordify=wordify(options["cmd"]), prefix=prefix))
+                fmt.format(name=options["cmd"], name_wordify=wordify(options["cmd"]),
+                           prefix=prefix))
         cases = "\n\t".expandtabs(8).join(cases)
 
         return """\


### PR DESCRIPTION
A call to `wordify()` was missing.

Example that breaks with the current version on master:
```python
import argparse

import shtab

parser = argparse.ArgumentParser(prog="test.py")
subparsers = parser.add_subparsers()

sub1 = subparsers.add_parser("subcommand-1", help="First subcommand")
sub2 = subparsers.add_parser("subcommand-2", help="Second subcommand")


print(shtab.complete_zsh(parser))
```