### PR TITLE
Fix colons in subcommands

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -51,7 +51,6 @@ FLAG_OPTION = (
 )
 OPTION_END = _HelpAction, _VersionAction
 OPTION_MULTI = _AppendAction, _AppendConstAction, _CountAction
-RE_ZSH_SPECIAL_CHARS = re.compile(r"([^\w\s.,()-])") # excessive but safe
 
 
 def mark_completer(shell):
@@ -444,7 +443,8 @@ complete -o filenames -F ${root_prefix} ${prog}""").safe_substitute(
 
 
 def escape_zsh(string):
-    return RE_ZSH_SPECIAL_CHARS.sub(r"\\\1", str(string))
+    # excessive but safe
+    return re.sub(r"([^\w\s.,()-])", r"\\\1", str(string))
 
 
 @mark_completer("zsh")

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -125,7 +125,7 @@ def complete2pattern(opt_complete, shell, choice_type2fn) -> bool:
 
 def wordify(string: str) -> str:
     """Replace non-word chars [-. :] with underscores [_]"""
-    return re.compile(r"[-.\s:]").sub("_", string)
+    return re.sub(r"[-.\s:]", "_", string)
 
 
 def get_public_subcommands(sub):

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -124,8 +124,8 @@ def complete2pattern(opt_complete, shell, choice_type2fn) -> bool:
 
 
 def wordify(string: str) -> str:
-    """Replace non-word chars [-. ] with underscores [_]"""
-    return string.replace("-", "_").replace(".", " ").replace(" ", "_")
+    """Replace non-word chars [-. :] with underscores [_]"""
+    return re.compile(r"[-.\s:]").sub("_", string)
 
 
 def get_public_subcommands(sub):
@@ -588,7 +588,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
 
     def command_list(prefix, options):
         name = " ".join([prog, *options["paths"]])
-        commands = "\n    ".join('"{}:{}"'.format(cmd, escape_zsh(opt["help"]))
+        commands = "\n    ".join('"{}:{}"'.format(escape_zsh(cmd), escape_zsh(opt["help"]))
                                  for cmd, opt in sorted(options["commands"].items()))
         return """
 {prefix}_commands() {{

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -209,6 +209,24 @@ def test_subparser_aliases(shell, caplog):
 
 
 @fix_shell
+def test_subparser_colons(shell, caplog):
+    parser = ArgumentParser(prog="test")
+    subparsers = parser.add_subparsers()
+    subparsers.add_parser("sub:cmd", help="help message")
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell=shell)
+    print(completion)
+
+    if shell == "bash":
+        shell = Bash(completion)
+        shell.compgen('-W "${_shtab_test_subparsers[*]}"', "s", "sub:cmd")
+        shell.compgen('-W "${_shtab_test_pos_0_choices[*]}"', "s", "sub:cmd")
+        shell.test('-z "$_shtab_test_COMPGEN"')
+
+    assert not caplog.record_tuples
+
+
+@fix_shell
 def test_add_argument_to_optional(shell, caplog):
     parser = ArgumentParser(prog="test")
     shtab.add_argument_to(parser, ["-s", "--shell"])


### PR DESCRIPTION
Subcommands like `hello:world` were formerly not being escaped properly.