### PR TITLE
Remove redundant code for Python <= 3.6

### DIFF
--- a/examples/docopt-greeter.py
+++ b/examples/docopt-greeter.py
@@ -21,4 +21,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     msg = "k thx bai!" if args.goodbye else "hai!"
-    print("{} says '{}' to {}".format(args.me, msg, args.you))
+    print(f"{args.me} says '{msg}' to {args.you}")

--- a/examples/pathcomplete.py
+++ b/examples/pathcomplete.py
@@ -23,4 +23,4 @@ def get_main_parser():
 if __name__ == "__main__":
     parser = get_main_parser()
     args = parser.parse_args()
-    print("received <file>=%r --dir=%r" % (args.file, args.dir))
+    print("received <file>={!r} --dir={!r}".format(args.file, args.dir))

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,8 +67,6 @@ classifiers=
     Topic :: Utilities
 [options]
 setup_requires=setuptools>=42; wheel; setuptools_scm[toml]>=3.4
-install_requires=
-    argparse; "3.0" <= python_version and python_version < "3.2"
 python_requires=>=3.7
 packages=find:
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,8 +78,6 @@ console_scripts=
 shtab=py.typed
 [options.packages.find]
 exclude=docs,tests
-[bdist_wheel]
-universal=1
 
 [flake8]
 max_line_length=99

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -78,7 +78,7 @@ def get_completer(shell):
 
 
 @total_ordering
-class Choice(object):
+class Choice:
     """
     Placeholder to mark a special completion `<type>`.
 
@@ -109,14 +109,14 @@ class Choice(object):
         return self.__cmp__(other) < 0
 
 
-class Optional(object):
+class Optional:
     """Example: `ArgumentParser.add_argument(..., choices=Optional.FILE)`."""
 
     FILE = [Choice("file")]
     DIR = DIRECTORY = [Choice("directory")]
 
 
-class Required(object):
+class Required:
     """Example: `ArgumentParser.add_argument(..., choices=Required.FILE)`."""
 
     FILE = [Choice("file", True)]
@@ -186,20 +186,20 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
 
             if hasattr(positional, "complete"):
                 # shtab `.complete = ...` functions
-                compgens.append(u"{}_pos_{}_COMPGEN={}".format(
+                compgens.append("{}_pos_{}_COMPGEN={}".format(
                     prefix, i, complete2pattern(positional.complete, "bash", choice_type2fn)))
 
             if positional.choices:
                 # choices (including subparsers & shtab `.complete` functions)
-                log.debug("choices:{}:{}".format(prefix, sorted(positional.choices)))
+                log.debug(f"choices:{prefix}:{sorted(positional.choices)}")
 
                 this_positional_choices = []
                 for choice in positional.choices:
                     if isinstance(choice, Choice):
                         # append special completion type to `compgens`
                         # NOTE: overrides `.complete` attribute
-                        log.debug("Choice.{}:{}:{}".format(choice.type, prefix, positional.dest))
-                        compgens.append(u"{}_pos_{}_COMPGEN={}".format(
+                        log.debug(f"Choice.{choice.type}:{prefix}:{positional.dest}")
+                        compgens.append("{}_pos_{}_COMPGEN={}".format(
                             prefix, i, choice_type2fn[choice.type]))
                     elif isinstance(positional.choices, dict):
                         # subparser, so append to list of subparsers & recurse
@@ -230,20 +230,20 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                         this_positional_choices.append(str(choice))
 
                 if this_positional_choices:
-                    choices.append(u"{}_pos_{}_choices=('{}')".format(
+                    choices.append("{}_pos_{}_choices=('{}')".format(
                         prefix, i, "' '".join(this_positional_choices)))
 
             # skip default `nargs` values
             if positional.nargs not in (None, "1", "?"):
-                nargs.append(u"{}_pos_{}_nargs={}".format(prefix, i, positional.nargs))
+                nargs.append(f"{prefix}_pos_{i}_nargs={positional.nargs}")
 
         if discovered_subparsers:
-            subparsers.append(u"{}_subparsers=('{}')".format(prefix,
-                                                             "' '".join(discovered_subparsers)))
-            log.debug("subcommands:{}:{}".format(prefix, discovered_subparsers))
+            subparsers.append("{}_subparsers=('{}')".format(prefix,
+                                                            "' '".join(discovered_subparsers)))
+            log.debug(f"subcommands:{prefix}:{discovered_subparsers}")
 
         # optional arguments
-        option_strings.append(u"{}_option_strings=('{}')".format(
+        option_strings.append("{}_option_strings=('{}')".format(
             prefix, "' '".join(get_option_strings(parser))))
         for optional in parser._get_optional_actions():
             if optional == SUPPRESS:
@@ -252,7 +252,7 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
             for option_string in optional.option_strings:
                 if hasattr(optional, "complete"):
                     # shtab `.complete = ...` functions
-                    compgens.append(u"{}_{}_COMPGEN={}".format(
+                    compgens.append("{}_{}_COMPGEN={}".format(
                         prefix, wordify(option_string),
                         complete2pattern(optional.complete, "bash", choice_type2fn)))
 
@@ -263,21 +263,21 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                         # append special completion type to `compgens`
                         # NOTE: overrides `.complete` attribute
                         if isinstance(choice, Choice):
-                            log.debug("Choice.{}:{}:{}".format(choice.type, prefix, optional.dest))
-                            compgens.append(u"{}_{}_COMPGEN={}".format(
+                            log.debug(f"Choice.{choice.type}:{prefix}:{optional.dest}")
+                            compgens.append("{}_{}_COMPGEN={}".format(
                                 prefix, wordify(option_string), choice_type2fn[choice.type]))
                         else:
                             # simple choice
                             this_optional_choices.append(str(choice))
 
                     if this_optional_choices:
-                        choices.append(u"{}_{}_choices=('{}')".format(
+                        choices.append("{}_{}_choices=('{}')".format(
                             prefix, wordify(option_string), "' '".join(this_optional_choices)))
 
                 # Check for nargs.
                 if optional.nargs is not None and optional.nargs != 1:
-                    nargs.append(u"{}_{}_nargs={}".format(prefix, wordify(option_string),
-                                                          optional.nargs))
+                    nargs.append("{}_{}_nargs={}".format(prefix, wordify(option_string),
+                                                         optional.nargs))
 
         # append recursion results
         subparsers.extend(sub_subparsers)
@@ -520,7 +520,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
                 # positional argument
                 all_commands[prefix]["arguments"].append(format_positional(sub))
             else:  # subparser
-                log.debug("choices:{}:{}".format(prefix, sorted(sub.choices)))
+                log.debug(f"choices:{prefix}:{sorted(sub.choices)}")
                 public_cmds = get_public_subcommands(sub)
                 for cmd, subparser in sub.choices.items():
                     if cmd not in public_cmds:
@@ -724,8 +724,7 @@ def complete_tcsh(parser, root_prefix=None, preamble="", choice_functions=None):
             # Multiple requirements
             nlist = []
             for nn, arg in ndict.items():
-                checks = [
-                    '[ "$cmd[{}]" == "{}" ]'.format(iidx, n) for iidx, n in enumerate(nn, start=2)]
+                checks = [f'[ "$cmd[{iidx}]" == "{n}" ]' for iidx, n in enumerate(nn, start=2)]
                 if arg.choices:
                     nlist.append('( {}echo "{}" || false )'.format(
                         ' && '.join(checks + ['']),                 # Append the separator

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import logging
 import re
 from argparse import (

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import logging
 import re
-import sys
 from argparse import (
     ONE_OR_MORE,
     REMAINDER,
@@ -807,15 +806,12 @@ def add_argument_to(
     parent  : argparse.ArgumentParser
       required in subcommand mode
     """
-    if isinstance(
-            option_string,
-            str if sys.version_info[0] > 2 else basestring          # NOQA
-    ):
+    if isinstance(option_string, str):
         option_string = [option_string]
     kwargs = {
         "choices": SUPPORTED_SHELLS, "default": None, "help": help,
         "action": completion_action(parent, preamble)}
-    if option_string[0][0] != "-":                                  # subparser mode
+    if option_string[0][0] != "-": # subparser mode
         kwargs.update(default=SUPPORTED_SHELLS[0], nargs="?")
         assert parent is not None, "subcommand mode: parent required"
     parser.add_argument(*option_string, **kwargs)

--- a/shtab/__main__.py
+++ b/shtab/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import sys
 

--- a/shtab/main.py
+++ b/shtab/main.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import argparse
 import logging
 import os

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -3,7 +3,6 @@ Tests for `shtab`.
 """
 import logging
 import subprocess
-import sys
 from argparse import ArgumentParser
 
 import pytest
@@ -183,7 +182,6 @@ def test_subparser_custom_complete(shell, caplog):
 
 
 @fix_shell
-@pytest.mark.skipif(sys.version_info[0] == 2, reason="requires Python 3.x")
 def test_subparser_aliases(shell, caplog):
     parser = ArgumentParser(prog="test")
     subparsers = parser.add_subparsers()

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -13,15 +13,14 @@ from shtab.main import get_main_parser, main
 fix_shell = pytest.mark.parametrize("shell", shtab.SUPPORTED_SHELLS)
 
 
-class Bash(object):
+class Bash:
     def __init__(self, init_script=""):
         self.init = init_script
 
     def test(self, cmd="1", failure_message=""):
         """Equivalent to `bash -c '{init}; [[ {cmd} ]]'`."""
         init = self.init + "\n" if self.init else ""
-        proc = subprocess.Popen([
-            "bash", "-o", "pipefail", "-ec", "{init}[[ {cmd} ]]".format(init=init, cmd=cmd)])
+        proc = subprocess.Popen(["bash", "-o", "pipefail", "-ec", f"{init}[[ {cmd} ]]"])
         stdout, stderr = proc.communicate()
         assert (0 == proc.wait() and not stdout and not stderr), """\
 {}


### PR DESCRIPTION
And upgrade syntax for 3.7+.