### PR TITLE
Support choices provided via the complete attribute

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -20,7 +20,7 @@ from itertools import starmap
 from string import Template
 from typing import Any, Dict, List
 from typing import Optional as Opt
-from typing import Sequence, Union
+from typing import Union
 
 # version detector. Precedence: installed dist, git, 'UNKNOWN'
 try:
@@ -112,8 +112,8 @@ class Choice:
 
 
 class CustomChoices:
-    def __init__(self, choices: Sequence[str]) -> None:
-        self.choices = tuple(choices)
+    def __init__(self, *choices: str) -> None:
+        self.choices = choices
         assert all(isinstance(c, str) for c in self.choices)
 
     def bash_choices(self, prefix: str, option_string: str) -> str:
@@ -128,8 +128,8 @@ class CustomChoices:
         return "(" + " ".join(self.choices) + ")"
 
 
-def custom_choices(choices: List[str]) -> CustomChoices:
-    return CustomChoices(choices)
+def custom_choices(*choices: str) -> CustomChoices:
+    return CustomChoices(*choices)
 
 
 class Optional:
@@ -277,7 +277,8 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                     if isinstance(optional.complete, CustomChoices):
                         choices.append(optional.complete.bash_choices(prefix, option_string))
                     else:
-                        comp_pattern_str = complete2pattern(optional.complete, "bash", choice_type2fn)
+                        comp_pattern_str = complete2pattern(optional.complete, "bash",
+                                                            choice_type2fn)
                         compgens.append(
                             f"{prefix}_{wordify(option_string)}_COMPGEN={comp_pattern_str}")
 

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -198,6 +198,22 @@ def test_subparser_custom_complete(shell, caplog):
 
 
 @fix_shell
+def test_custom_choices(shell, caplog):
+    parser = ArgumentParser(prog="test")
+    action = parser.add_argument("--optA")
+    action.complete = shtab.custom_choices(["yes", "no", "maybe"])
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell=shell)
+    print(completion)
+
+    if shell == "bash":
+        shell = Bash(completion)
+        shell.compgen('-W "${_shtab_test___optA_choices[*]}"', "m", "maybe")
+
+    assert not caplog.record_tuples
+
+
+@fix_shell
 def test_subparser_aliases(shell, caplog):
     parser = ArgumentParser(prog="test")
     subparsers = parser.add_subparsers()

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -201,7 +201,7 @@ def test_subparser_custom_complete(shell, caplog):
 def test_custom_choices(shell, caplog):
     parser = ArgumentParser(prog="test")
     action = parser.add_argument("--optA")
-    action.complete = shtab.custom_choices(["yes", "no", "maybe"])
+    action.complete = shtab.custom_choices("yes", "no", "maybe")
     with caplog.at_level(logging.INFO):
         completion = shtab.complete(parser, shell=shell)
     print(completion)


### PR DESCRIPTION
I am interested in implementing #68. It is my first time looking at the shtab source code so do need some guidance. This pull request only implements the option to do like

```python
# for type=Optional[bool]
action.complete = shtab.custom_choices("false", "true", "null")
```

Later I might also want to implement support the following, which could be relevant for discussing how to change the code now and later on.

```python
# for type=Optional[Path_fr]
action.complete = [shtab.FILE, shtab.custom_choices("null")]
```

For the moment I have only implemented the support in optional actions. I will wait for some feedback before doing it for positionals.