### PR TITLE
mark stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         changelog=$(git log --pretty='format:%d%n- %s%n%b---' $(git tag --sort=v:refname | tail -n2 | head -n1)..HEAD)
         tag="${GITHUB_REF#refs/tags/}"
-        gh release create --title "shtab $tag beta" --draft --notes "$changelog" "$tag" dist/${{ steps.dist.outputs.whl }} dist/${{ steps.dist.outputs.targz }}
+        gh release create --title "shtab $tag stable" --draft --notes "$changelog" "$tag" dist/${{ steps.dist.outputs.whl }} dist/${{ steps.dist.outputs.targz }}
       env:
         GH_TOKEN: ${{ github.token }}
     - name: Docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.7"
 keywords = ["tab", "complete", "completion", "shell", "bash", "zsh", "argparse"]
 license = {text = "Apache-2.0"}
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Environment :: MacOS X",
     "Environment :: Other Environment",


### PR DESCRIPTION
[4 years old](https://github.com/iterative/shtab/commit/0f05533610308ca2c09c53d9a6b67cfe5f9eec98) and [1M+ downloads a month](https://pypistats.org/packages/shtab). Probably time to say it's "stable"?