### PR TITLE
zsh: allow to eval zsh completion

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -659,7 +659,15 @@ ${command_cases}
 ${preamble}
 
 typeset -A opt_args
-${root_prefix} "$@\"""").safe_substitute(
+
+if [[ $zsh_eval_context[-1] == eval ]]; then
+  # eval/source/. command, register function for later
+  compdef ${root_prefix} -N ${prog}
+else
+  # autoload from fpath, call function directly
+  ${root_prefix} "$@\"
+fi
+""").safe_substitute(
         prog=prog,
         root_prefix=root_prefix,
         command_cases="\n".join(starmap(command_case, sorted(subcommands.items()))),

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -110,7 +110,7 @@ def test_prog_scripts(shell, caplog, capsys):
             "_describe 'script.py commands' _commands",
             "_shtab_shtab_options+=(': :_shtab_shtab_commands' '*::: :->script.py')",
             "script.py)",
-            "compdef _shtab_shtab -N script.py",]
+            "compdef _shtab_shtab -N script.py"]
     elif shell == "tcsh":
         assert script_py == ["complete script.py \\"]
     else:

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -106,8 +106,11 @@ def test_prog_scripts(shell, caplog, capsys):
         assert script_py == ["complete -o filenames -F _shtab_shtab script.py"]
     elif shell == "zsh":
         assert script_py == [
-            "#compdef script.py", "_describe 'script.py commands' _commands",
-            "_shtab_shtab_options+=(': :_shtab_shtab_commands' '*::: :->script.py')", "script.py)"]
+            "#compdef script.py",
+            "_describe 'script.py commands' _commands",
+            "_shtab_shtab_options+=(': :_shtab_shtab_commands' '*::: :->script.py')",
+            "script.py)",
+            "compdef _shtab_shtab -N script.py",]
     elif shell == "tcsh":
         assert script_py == ["complete script.py \\"]
     else:
@@ -271,7 +274,7 @@ def test_add_argument_to_positional(shell, caplog, capsys):
             assert exc.value.code == 0
     completion, err = capsys.readouterr()
     print(completion)
-    assert completion_manual == completion.rstrip()
+    assert completion_manual.rstrip() == completion.rstrip()
     assert not err
 
     if shell == "bash":

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -106,10 +106,8 @@ def test_prog_scripts(shell, caplog, capsys):
         assert script_py == ["complete -o filenames -F _shtab_shtab script.py"]
     elif shell == "zsh":
         assert script_py == [
-            "#compdef script.py",
-            "_describe 'script.py commands' _commands",
-            "_shtab_shtab_options+=(': :_shtab_shtab_commands' '*::: :->script.py')",
-            "script.py)",
+            "#compdef script.py", "_describe 'script.py commands' _commands",
+            "_shtab_shtab_options+=(': :_shtab_shtab_commands' '*::: :->script.py')", "script.py)",
             "compdef _shtab_shtab -N script.py"]
     elif shell == "tcsh":
         assert script_py == ["complete script.py \\"]


### PR DESCRIPTION
Allow to run `eval "$(my-prog --print-completion zsh)"` to enable completion in the current zsh environment.

This change is inspired by https://github.com/pypa/pip/pull/12173 and https://github.com/pallets/click/pull/2544.