### PR TITLE
explicitly specify build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "shtab/_dist_ver.py"


### PR DESCRIPTION
`setuptools.build_meta:__legacy__` will be used if build-backend is not specified. Use `setuptools.build_meta` instead.

https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour
https://pydocbrowser.github.io/setuptools/latest/setuptools.build_meta._BuildMetaLegacyBackend.html