### PR TITLE
replace all non-word characters with wordify

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -129,8 +129,8 @@ def complete2pattern(opt_complete, shell: str, choice_type2fn) -> str:
 
 
 def wordify(string: str) -> str:
-    r"""Replace non-word chars [\W] with underscores [_]"""
-    return re.sub(r"\W", "_", string)
+    """Replace non-word chars [\\W] with underscores [_]"""
+    return re.sub("\\W", "_", string)
 
 
 def get_public_subcommands(sub):

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -129,8 +129,8 @@ def complete2pattern(opt_complete, shell: str, choice_type2fn) -> str:
 
 
 def wordify(string: str) -> str:
-    """Replace non-word chars [-. :] with underscores [_]"""
-    return re.sub(r"[-.\s:]", "_", string)
+    r"""Replace non-word chars [\W] with underscores [_]"""
+    return re.sub(r"\W", "_", string)
 
 
 def get_public_subcommands(sub):

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -242,6 +242,25 @@ def test_subparser_colons(shell, caplog):
 
 
 @fix_shell
+def test_subparser_slashes(shell, caplog):
+    parser = ArgumentParser(prog="test")
+    subparsers = parser.add_subparsers()
+    subparsers.add_parser("sub/cmd", help="help message")
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell=shell)
+    print(completion)
+
+    if shell == "bash":
+        shell = Bash(completion)
+        shell.compgen('-W "${_shtab_test_subparsers[*]}"', "s", "sub/cmd")
+        shell.compgen('-W "${_shtab_test_pos_0_choices[*]}"', "s", "sub/cmd")
+        shell.test('-z "${_shtab_test_COMPGEN-}"')
+    elif shell == "zsh":
+        # make sure the slash was properly substituted to avoid syntax errors
+        assert "_shtab_test_sub/cmd" not in completion
+
+
+@fix_shell
 def test_add_argument_to_optional(shell, caplog):
     parser = ArgumentParser(prog="test")
     shtab.add_argument_to(parser, ["-s", "--shell"])

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -256,8 +256,8 @@ def test_subparser_slashes(shell, caplog):
         shell.compgen('-W "${_shtab_test_pos_0_choices[*]}"', "s", "sub/cmd")
         shell.test('-z "${_shtab_test_COMPGEN-}"')
     elif shell == "zsh":
-        # make sure the slash was properly substituted to avoid syntax errors
         assert "_shtab_test_sub/cmd" not in completion
+        assert "_shtab_test_sub_cmd" in completion
 
 
 @fix_shell


### PR DESCRIPTION
Use the regular expression set `\W` to replace all non-word characters instead of the fixed set `[-.\s:]` in `wordify`. I also added a test for subcommands containing slashes in their name as an example. This could be tested more robustly, though that would require more knowledge of some shell completion internals than I currently have.

Closes #165