### PR TITLE
chore: add codespell pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
     entry: TODO
     types: [text]
     exclude: ^(.pre-commit-config.yaml|.github/workflows/test.yml)$
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.1
+  hooks:
+    - id: codespell
+      args: ["--skip", "aider/website/docs/languages.md"]
+      additional_dependencies:
+        - tomli
 - repo: https://github.com/PyCQA/flake8
   rev: 7.2.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,4 +127,3 @@ skip = """./.*,*/.metadata,*.xml,configure,*Makefile*,config*,*.m4,man.html"""
 quiet-level=2
 ignore-regex = '\\[fnrstv]'
 builtin = "clear,rare,informal"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,13 @@ log_level = "DEBUG"
 python_files = ["test_*.py"]
 testpaths = ["tests"]
 addopts = "-v --tb=short -rxs -W=error --durations=0 --cov=shtab --cov-report=term-missing --cov-report=xml"
+
+[tool.codespell]
+ignore-words-list = """
+fo
+"""
+skip = """./.*,*/.metadata,*.xml,configure,*Makefile*,config*,*.m4,man.html"""
+quiet-level=2
+ignore-regex = '\\[fnrstv]'
+builtin = "clear,rare,informal"
+


### PR DESCRIPTION
- Add codespell pre-commit hook to check for common misspellings
- Configure codespell to skip specific files and directories
- Add codespell configuration in pyproject.toml