### PR TITLE
Add ability to write completions to the file

### DIFF
--- a/docs/use.md
+++ b/docs/use.md
@@ -74,7 +74,7 @@ Below are various examples of enabling `shtab`'s own tab completion scripts.
     ```sh
     mkdir -p ~/.zsh/completions
     fpath=($fpath ~/.zsh/completions)  # must be before `compinit` lines
-    shtab --shell=zsh shtab.main.get_main_parser > ~/.zsh/completions/_shtab
+    shtab --shell=zsh shtab.main.get_main_parser -o ~/.zsh/completions/_shtab
     ```
 
 === "tcsh"

--- a/shtab/main.py
+++ b/shtab/main.py
@@ -14,6 +14,8 @@ def get_main_parser():
     parser.add_argument("parser", help="importable parser (or function returning parser)")
     parser.add_argument("--version", action="version", version="%(prog)s " + __version__)
     parser.add_argument("-s", "--shell", default=SUPPORTED_SHELLS[0], choices=SUPPORTED_SHELLS)
+    parser.add_argument("-o", "--output", help="write output to file instead of stdout",
+                        type=argparse.FileType("w"), default=sys.stdout)
     parser.add_argument("--prefix", help="prepended to generated functions to avoid clashes")
     parser.add_argument("--preamble", help="prepended to generated script")
     parser.add_argument("--prog", help="custom program name (overrides `parser.prog`)")
@@ -54,4 +56,4 @@ def main(argv=None):
         other_parser.prog = args.prog
     print(
         complete(other_parser, shell=args.shell, root_prefix=args.prefix
-                 or args.parser.split(".", 1)[0], preamble=args.preamble))
+                 or args.parser.split(".", 1)[0], preamble=args.preamble), file=args.output)

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 import pytest
 
 import shtab
-from shtab.main import get_main_parser, main
+from shtab.main import extract_stdout, get_main_parser, main
 
 fix_shell = pytest.mark.parametrize("shell", shtab.SUPPORTED_SHELLS)
 
@@ -342,3 +342,17 @@ def test_path_completion_after_redirection(caplog, change_dir):
         shell.test('"${COMPREPLY[@]}" = "test_file.txt"', f"Redirection {redirection} failed")
 
     assert not caplog.record_tuples
+
+
+def test_extract_stdout(tmp_path):
+    path = tmp_path / "completions"
+    with extract_stdout(path) as output:
+        output.write("completion")
+    assert path.read_text() == "completion"
+
+
+def test_extract_stdout_empty(capsys):
+    with extract_stdout(None) as output:
+        output.write("completion")
+    captured = capsys.readouterr()
+    assert captured.out == "completion"


### PR DESCRIPTION
It might be useful to write file directly instead of forwarding output to it, e.g. if files are generated automatically in pipeline (via tox or whatever is used) and distributed together with an application. No append option supported.

This commit also updates docs for cases when it is possible to write file directly and no sudo required to write there