### PR TITLE
Fix bash quoting, add type hints, code cleanup

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -439,18 +439,17 @@ ${root_prefix}() {
 
   if [[ $pos_only = 0 && "${completing_word}" == -* ]]; then
     # optional argument started: use option strings
-    COMPREPLY=( $(compgen -W "${current_option_strings[*]}" -- "${completing_word}") )
+    mapfile -t COMPREPLY < <(compgen -W "${current_option_strings[*]}" -- "${completing_word}")
   elif [[ "${previous_word}" == ">" || "${previous_word}" == ">>" ||
           "${previous_word}" =~ ^[12]">" || "${previous_word}" =~ ^[12]">>" ]]; then
     # handle redirection operators
-    COMPREPLY=( $(compgen -f -- "${completing_word}") )
+    mapfile -t COMPREPLY < <(compgen -f -- "${completing_word}")
   else
     # use choices & compgen
-    local IFS=$'\\n' # items may contain spaces, so delimit using newline
-    COMPREPLY=( $([ -n "${current_action_compgen}" ] \\
-                  && "${current_action_compgen}" "${completing_word}") )
-    unset IFS
-    COMPREPLY+=( $(compgen -W "${current_action_choices[*]}" -- "${completing_word}") )
+    [ -n "${current_action_compgen}" ] &&
+      mapfile -t COMPREPLY < <("${current_action_compgen}" "${completing_word}")
+    mapfile -t -O "${#COMPREPLY[@]}" COMPREPLY < <(
+      compgen -W "${current_action_choices[*]}" -- "${completing_word}")
   fi
 
   return 0

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -17,6 +17,7 @@ from argparse import (
 from collections import defaultdict
 from functools import total_ordering
 from itertools import starmap
+from shlex import join, quote
 from string import Template
 from typing import Any, Dict, List
 from typing import Optional as Opt
@@ -187,7 +188,7 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
             if hasattr(positional, "complete"):
                 # shtab `.complete = ...` functions
                 comp_pattern = complete2pattern(positional.complete, "bash", choice_type2fn)
-                compgens.append(f"{prefix}_pos_{i}_COMPGEN={comp_pattern}")
+                compgens.append(f"{prefix}_pos_{i}_COMPGEN={quote(comp_pattern)}")
 
             if positional.choices:
                 # choices (including subparsers & shtab `.complete` functions)
@@ -199,7 +200,8 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                         # append special completion type to `compgens`
                         # NOTE: overrides `.complete` attribute
                         log.debug(f"Choice.{choice.type}:{prefix}:{positional.dest}")
-                        compgens.append(f"{prefix}_pos_{i}_COMPGEN={choice_type2fn[choice.type]}")
+                        compgens.append(f"{prefix}_pos_{i}_COMPGEN="
+                                        f"{quote(choice_type2fn[choice.type])}")
                     elif isinstance(positional.choices, dict):
                         # subparser, so append to list of subparsers & recurse
                         log.debug("subcommand:%s", choice)
@@ -229,21 +231,18 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                         this_positional_choices.append(str(choice))
 
                 if this_positional_choices:
-                    choices_str = "' '".join(this_positional_choices)
-                    choices.append(f"{prefix}_pos_{i}_choices=('{choices_str}')")
+                    choices.append(f"{prefix}_pos_{i}_choices=({join(this_positional_choices)})")
 
             # skip default `nargs` values
             if positional.nargs not in (None, "1", "?"):
-                nargs.append(f"{prefix}_pos_{i}_nargs={positional.nargs}")
+                nargs.append(f"{prefix}_pos_{i}_nargs={quote(str(positional.nargs))}")
 
         if discovered_subparsers:
-            subparsers_str = "' '".join(discovered_subparsers)
-            subparsers.append(f"{prefix}_subparsers=('{subparsers_str}')")
+            subparsers.append(f"{prefix}_subparsers=({join(discovered_subparsers)})")
             log.debug(f"subcommands:{prefix}:{discovered_subparsers}")
 
         # optional arguments
-        options_strings_str = "' '".join(get_option_strings(parser))
-        option_strings.append(f"{prefix}_option_strings=('{options_strings_str}')")
+        option_strings.append(f"{prefix}_option_strings=({join(get_option_strings(parser))})")
         for optional in parser._get_optional_actions():
             if optional == SUPPRESS:
                 continue
@@ -252,8 +251,8 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                 if hasattr(optional, "complete"):
                     # shtab `.complete = ...` functions
                     comp_pattern_str = complete2pattern(optional.complete, "bash", choice_type2fn)
-                    compgens.append(
-                        f"{prefix}_{wordify(option_string)}_COMPGEN={comp_pattern_str}")
+                    compgens.append(f"{prefix}_{wordify(option_string)}_COMPGEN="
+                                    f"{join(comp_pattern_str)}")
 
                 if optional.choices:
                     # choices (including shtab `.complete` functions)
@@ -264,20 +263,20 @@ def get_bash_commands(root_parser, root_prefix, choice_functions=None):
                         if isinstance(choice, Choice):
                             log.debug(f"Choice.{choice.type}:{prefix}:{optional.dest}")
                             func_str = choice_type2fn[choice.type]
-                            compgens.append(
-                                f"{prefix}_{wordify(option_string)}_COMPGEN={func_str}")
+                            compgens.append(f"{prefix}_{wordify(option_string)}_COMPGEN="
+                                            f"{quote(func_str)}")
                         else:
                             # simple choice
                             this_optional_choices.append(str(choice))
 
                     if this_optional_choices:
-                        this_choices_str = "' '".join(this_optional_choices)
-                        choices.append(
-                            f"{prefix}_{wordify(option_string)}_choices=('{this_choices_str}')")
+                        choices.append(f"{prefix}_{wordify(option_string)}_choices="
+                                       f"({join(this_optional_choices)})")
 
                 # Check for nargs.
                 if optional.nargs is not None and optional.nargs != 1:
-                    nargs.append(f"{prefix}_{wordify(option_string)}_nargs={optional.nargs}")
+                    nargs.append(f"{prefix}_{wordify(option_string)}_nargs="
+                                 f"{quote(str(optional.nargs))}")
 
         # append recursion results
         subparsers.extend(sub_subparsers)
@@ -468,11 +467,6 @@ complete -o filenames -F ${root_prefix} ${prog}""").safe_substitute(
     )
 
 
-def escape_zsh(string):
-    # excessive but safe
-    return re.sub(r"([^\w\s.,()-])", r"\\\1", str(string))
-
-
 @mark_completer("zsh")
 def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
     """
@@ -500,7 +494,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
                 nargs=('"(- : *)"' if is_opt_end(opt) else '"*"' if is_opt_multiline(opt) else ""),
                 options=("{{{}}}".format(",".join(opt.option_strings)) if len(opt.option_strings)
                          > 1 else '"{}"'.format("".join(opt.option_strings))),
-                help=escape_zsh(get_help(opt) if opt.help else ""),
+                help=quote(get_help(opt) if opt.help else ""),
                 dest=opt.dest,
                 pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
                     opt, "complete") else
@@ -512,7 +506,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
         get_help = parser._get_formatter()._expand_help
         return '"{nargs}:{help}:{pattern}"'.format(
             nargs={ONE_OR_MORE: "(*)", ZERO_OR_MORE: "(*):", REMAINDER: "(-)*"}.get(opt.nargs, ""),
-            help=escape_zsh((get_help(opt) if opt.help else opt.dest).strip().split("\n")[0]),
+            help=quote((get_help(opt) if opt.help else opt.dest).strip().split("\n")[0]),
             pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
                 opt, "complete") else
             (choice_type2fn[opt.choices[0].type] if isinstance(opt.choices[0], Choice) else
@@ -644,7 +638,7 @@ curcontext="$curcontext" one_or_more='(*)' remainder='(-)*' default='*::: :->{na
 
     def command_list(prefix, options):
         name = " ".join([prog, *options["paths"]])
-        commands = "\n    ".join(f'"{escape_zsh(cmd)}:{escape_zsh(opt["help"])}"'
+        commands = "\n    ".join(f'{quote(cmd)}:{quote(opt["help"])}'
                                  for cmd, opt in sorted(options["commands"].items()))
         return f"""
 {prefix}_commands() {{
@@ -768,8 +762,7 @@ def complete_tcsh(parser, root_prefix=None, preamble="", choice_functions=None):
             for nn, arg in ndict.items():
                 if arg.choices:
                     checks = [f'[ "$cmd[{iidx}]" == "{n}" ]' for iidx, n in enumerate(nn, start=2)]
-                    choices_str = "' '".join(arg.choices)
-                    checks_str = ' && '.join(checks + [f"echo '{choices_str}'"])
+                    checks_str = ' && '.join(checks + [f"echo {join(arg.choices)}"])
                     nlist.append(f"( {checks_str} || false )")
             # Ugly hack
             nlist_str = ' || '.join(nlist)


### PR DESCRIPTION
I found your project while looking for how to get bash completion automatically from `ArgumentParser.` Sadly Ubuntu 24.04 ships a broken version, so I had a look at your GitHub repository. Great work. Sadly there are several pending open issues and other PRs, so I hope you will find some time to work on this again soon.

1. While looking at the code I noticed that type-annotations were incomplete. As I'm a huge fan of type-annotated code myself, I took my time to add it to all functions.[^1]
2. I upgraded the old annotations to use `list[…]` instead of `typing.Lits[…]` and such.
3. As usual `mypy` found some minor issues, which I also fixed. See individual commits at the front.
4. While looking at the generated code `shellcheck` found many issues, mostly related to missing quotes. I fixed the code, which generates those. See individual commits in the middle.
5. `__init__.py` is quiet large and contains mixed Python/shell code. Maybe it might be a good idea to move the shell-code to separate files; see last commit.

[^1]: For complete type annotations [`typing.Protocol`](https://docs.python.org/3/library/typing.html#typing.Protocol) from Python 3.8 ([EoL last year](https://devguide.python.org/versions/)) is needed. Therefor I bumped the minimum supported version to 3.8 not that 3.14 got released. By using `from __future__ import annotations`  and `if TYPE_CHECKING:` the code still runs with 3.8. Using `from collections.abc import …` instead of `from typing import …` works only since Python 3.9 (EoL this month). Raising the minimum version to `3.9` thus might be preferred.

If you prefer I can send you smaller pull requests only doing one thing at a time. But before I spend more time on this, I'd like to get your feedback if such changes are preferred or not.