### PR TITLE
update minimum setuptools requirement for SPDX license support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
license = "Apache-2.0" (a spdx license expression) is used in pyproject.toml.

Quoting https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html :

"Support for project.license-files and SPDX license expressions in project.license (PEP 639) were introduced in version 77.0.0."