### PR TITLE
feat: Add support for fish shell

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -9,4 +9,4 @@ pylint:
   run: false
 mccabe:
   options:
-    max-complexity: 25
+    max-complexity: 26

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@
     - `bash`
     - `zsh`
     - `tcsh`
+    - `fish`
 - Supports
     - [`argparse`](https://docs.python.org/library/argparse)
     - [`docopt`](https://pypi.org/project/docopt) (via [`argopt`](https://pypi.org/project/argopt))

--- a/docs/use.md
+++ b/docs/use.md
@@ -24,18 +24,18 @@ Below are various examples of enabling `shtab`'s own tab completion scripts.
 !!! info
     If both shtab and the module it's completing are globally importable, eager
     usage is an option. "Eager" means automatically updating completions each
-    time a terminal is opened.
+    time a terminal is opened, and likely should not use the `-u, --error-unimportable` flag.
 
 === "bash"
 
+    See <https://github.com/scop/bash-completion/blob/main/doc/configuration.md>, e.g.:
+
     ```sh
-    shtab --shell=bash shtab.main.get_main_parser --error-unimportable \
+    shtab -u --shell=bash shtab.main.get_main_parser \
       | sudo tee "$BASH_COMPLETION_COMPAT_DIR"/shtab
     ```
 
-=== "Eager bash"
-
-    There are a few options:
+    Eager:
 
     ```sh
     # Install locally
@@ -62,14 +62,14 @@ Below are various examples of enabling `shtab`'s own tab completion scripts.
 
     ```sh
     # note the underscore `_` prefix
-    shtab --shell=zsh shtab.main.get_main_parser --error-unimportable \
+    shtab -u --shell=zsh shtab.main.get_main_parser \
       | sudo tee /usr/local/share/zsh/site-functions/_shtab
     ```
 
-=== "Eager zsh"
+    Eager:
 
-    To be more eager, place the generated script somewhere in `$fpath`. For
-    example, add these lines to the top of `~/.zshrc`:
+    Place the generated script somewhere in `$fpath`.
+    For example, add these lines to the top of `~/.zshrc`:
 
     ```sh
     mkdir -p ~/.zsh/completions
@@ -80,13 +80,11 @@ Below are various examples of enabling `shtab`'s own tab completion scripts.
 === "tcsh"
 
     ```sh
-    shtab --shell=tcsh shtab.main.get_main_parser --error-unimportable \
+    shtab -u --shell=tcsh shtab.main.get_main_parser \
       | sudo tee /etc/profile.d/shtab.completion.csh
     ```
 
-=== "Eager tcsh"
-
-    There are a few options:
+    Eager:
 
     ```sh
     # Install locally
@@ -96,6 +94,20 @@ Below are various examples of enabling `shtab`'s own tab completion scripts.
     # Install system-wide
     echo 'shtab --shell=tcsh shtab.main.get_main_parser | source /dev/stdin' \
       | sudo tee /etc/profile.d/eager-completion.csh
+    ```
+
+=== "fish"
+
+    See <https://fishshell.com/docs/current/completions.html#where-to-put-completions>, e.g.:
+
+    ```sh
+    # Install locally
+    shtab -u --shell=fish shtab.main.get_main_parser \
+      -o ~/.config/fish/completions/shtab.fish
+
+    # Install system-wide
+    shtab -u --shell=fish shtab.main.get_main_parser \
+      | sudo tee /usr/share/fish/vendor_completions.d/shtab.fish
     ```
 
 !!! tip
@@ -143,6 +155,13 @@ Assuming this code example is installed in `MY_PROG.command.main`, simply run:
     ```sh
     shtab --shell=tcsh -u MY_PROG.command.main.get_main_parser \
       | sudo tee /etc/profile.d/MY_PROG.completion.csh
+    ```
+
+=== "fish"
+
+    ```sh
+    shtab --shell=fish -u MY_PROG.command.main.get_main_parser \
+      | sudo tee /usr/share/fish/vendor_completions.d/MY_PROG.fish
     ```
 
 ## Library Usage

--- a/examples/customcomplete.py
+++ b/examples/customcomplete.py
@@ -10,7 +10,7 @@ import shtab  # for completion magic
 
 TXT_FILE = {
     "bash": "_shtab_greeter_compgen_TXTFiles", "zsh": "_files -g '(*.txt|*.TXT)'",
-    "tcsh": "f:*.txt"}
+    "tcsh": "f:*.txt", "fish": "(__fish_complete_suffix .txt)"}
 PREAMBLE = {
     "bash": """
 # $1=COMP_WORDS[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [{name = "tqdm developers", email = "devs@tqdm.ml"}]
 description = "Automagic shell tab completion for Python CLI applications"
 readme = "README.rst"
 requires-python = ">=3.9"
-keywords = ["tab", "complete", "completion", "shell", "bash", "zsh", "argparse"]
+keywords = ["tab", "completion", "shell", "bash", "zsh", "tcsh", "fish", "argparse"]
 license = {text = "MPL-2.0"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -791,7 +791,6 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
 
     See `complete` for other arguments.
     """
-
     prog = parser.prog
     completions = []
 
@@ -801,6 +800,25 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
     choice_type2fn = {k: v["fish"] for k, v in CHOICE_FUNCTIONS.items()}
     if choice_functions:
         choice_type2fn.update(choice_functions)
+
+    def start_output(path, same_level):
+        output = ["complete", "-c", prog]
+        if len(path) > 0:
+            cond = '; and '.join(f"__fish_seen_subcommand_from {cmd}" for cmd in path)
+            if same_level != "":
+                cond += f"; and not __fish_seen_subcommand_from {same_level}"
+            output.append(f'-n "{cond}"')
+        else:
+            output.append('-n "__fish_use_subcommand"')
+        return output
+
+    def get_specials(arg):
+        if arg.choices:
+            yield f'-rka "{join(map(str, arg.choices))}"'
+        elif hasattr(arg, 'complete'):
+            complete_fn = complete2pattern(arg.complete, 'fish', choice_type2fn)
+            if complete_fn:
+                yield f'-rka "{complete_fn}"'
 
     def recurse_parser(cparser: ArgumentParser, path: list[str], same_level: str):
         """
@@ -813,28 +831,11 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
         """
         log_prefix = "| " * len(path)
         log.debug("%sParser @ %d", log_prefix, len(path))
-
         for optional in cparser._get_optional_actions():
             log.debug("%s| Optional: %s", log_prefix, optional.dest)
-
             if optional.help == SUPPRESS:
                 continue
-
-            output = ["complete", "-c", prog]
-
-            if len(path) > 0:
-                # Show option only if in subcommand path, and no subcommand on other level is shown
-                cond_path = [f"__fish_seen_subcommand_from {cmd}" for cmd in path]
-
-                cond_level = ""
-                if same_level != "":
-                    cond_level = f"; and not __fish_seen_subcommand_from {same_level}"
-
-                cond = '; and '.join(cond_path) + cond_level
-                output.append(f'-n "{cond}"')
-            else:
-                output.append('-n "__fish_use_subcommand"')
-
+            output = start_output(path, same_level)
             for optional_str in optional.option_strings:
                 log.debug("%s| | %s", log_prefix, optional_str)
                 if optional_str.startswith("--"):
@@ -849,70 +850,31 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
             else:
                 output.append("-F")
 
-            # Offer the different choices
-            if optional.choices:
-                output.append(f'-rka "{join(map(str, optional.choices))}"')
-            elif hasattr(optional, "complete"):
-                complete_fn = complete2pattern(optional.complete, 'fish', choice_type2fn)
-                if complete_fn:
-                    output.append(f'-rka "{complete_fn}"')
-
+            output.extend(get_specials(optional))
             if optional.help:
                 output.append(f'-d {quote(optional.help)}')
-
             completions.append(' '.join(output))
-
         for positional in cparser._get_positional_actions():
             if positional.help == SUPPRESS:
                 continue
-
             log.debug("%s| Positional #%d: %s", log_prefix, len(path) + 1, positional.dest)
-
-            if isinstance(positional.choices, dict):
-                # Positional subcommand
+            if isinstance(positional.choices, dict): # Positional subcommand
                 public = get_public_subcommands(positional)
                 same_level = ' '.join(public)
-
                 for subcmd, subparser in positional.choices.items():
                     if subcmd not in public:
                         continue
-
                     log.debug("%s| | SubParser: %s", log_prefix, subcmd)
-                    output = ["complete", "-c", prog]
-
-                    if len(path) > 0:
-                        cond_path = [f"__fish_seen_subcommand_from {cmd}" for cmd in path]
-
-                        cond_level = ""
-                        if same_level != "":
-                            cond_level = f"; and not __fish_seen_subcommand_from {same_level}"
-
-                        cond = '; and '.join(cond_path) + cond_level
-                        output.append(f'-n "{cond}"')
-                    else:
-                        output.append('-n "__fish_use_subcommand"')
-
-                    output.append("-f")
-                    output.append(f"-a {subcmd}")
-
+                    output = start_output(path, same_level)
+                    output.append(f"-fa {subcmd}")
                     if subparser.description:
                         desc = subparser.description.strip().split("\n")[0]
                         output.append(f'-d {quote(desc)}')
-
                     completions.append(' '.join(output))
-
                     same_level_without_current = ' '.join(filter(lambda c: c != subcmd, public))
                     recurse_parser(subparser, path + [subcmd], same_level_without_current)
-
-            else:
-                # Simple argument (file, name...)
-                output = ["complete", "-c", prog]
-
-                if len(path) > 0:
-                    cond = '; and '.join([f"__fish_seen_subcommand_from {cmd}" for cmd in path])
-                    output.append(f'-n "{cond}"')
-                else:
-                    output.append('-n "__fish_use_subcommand"')
+            else:                                    # Simple argument (file, name...)
+                output = start_output(path, "")
 
                 # Allow file propositions specifically for this argument
                 output.append("-F")
@@ -920,7 +882,6 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                 if positional.help:
                     desc = positional.help.strip().split("\n")[0]
                     output.append(f'-d {quote(desc)}')
-
                 completions.append(' '.join(output))
 
     recurse_parser(parser, [], "")

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -28,7 +28,7 @@ CHOICE_FUNCTIONS: dict[str, dict[str, str]] = {
     "file": {"bash": "_shtab_compgen_files", "zsh": "_files", "tcsh": "f", "fish": ""},
     "directory": {
         "bash": "_shtab_compgen_dirs", "zsh": "_files -/", "tcsh": "d",
-        "fish": "__fish_complete_directories"}}
+        "fish": "(__fish_complete_directories)"}}
 FILE = CHOICE_FUNCTIONS["file"]
 DIRECTORY = DIR = CHOICE_FUNCTIONS["directory"]
 FLAG_OPTION = (
@@ -851,11 +851,11 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
 
             # Offer the different choices
             if optional.choices:
-                output.append(f'-r -a "{join(map(str, optional.choices))}"')
+                output.append(f'-rka "{join(map(str, optional.choices))}"')
             elif hasattr(optional, "complete"):
                 complete_fn = complete2pattern(optional.complete, 'fish', choice_type2fn)
                 if complete_fn:
-                    output.append(f'-r -a "{complete_fn}"')
+                    output.append(f'-rka "{complete_fn}"')
 
             if optional.help:
                 output.append(f'-d {quote(optional.help)}')

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -842,14 +842,6 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                     output.append(f"-l {optional_str[2:]}")
                 elif optional_str.startswith("-"):
                     output.append(f"-s {optional_str[1:]}")
-
-            # Disable file and directories completion if no type is provided
-            # (by default, Fish always suggests files and directories)
-            if optional.type is None:
-                output.append("-f")
-            else:
-                output.append("-F")
-
             output.extend(get_specials(optional))
             if optional.help:
                 output.append(f'-d {quote(optional.help)}')
@@ -866,7 +858,7 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                         continue
                     log.debug("%s| | SubParser: %s", log_prefix, subcmd)
                     output = start_output(path, same_level)
-                    output.append(f"-fa {subcmd}")
+                    output.append(f"-a {subcmd}")
                     if subparser.description:
                         desc = subparser.description.strip().split("\n")[0]
                         output.append(f'-d {quote(desc)}')
@@ -875,10 +867,6 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                     recurse_parser(subparser, path + [subcmd], same_level_without_current)
             else:                                    # Simple argument (file, name...)
                 output = start_output(path, "")
-
-                # Allow file propositions specifically for this argument
-                output.append("-F")
-
                 if positional.help:
                     desc = positional.help.strip().split("\n")[0]
                     output.append(f'-d {quote(desc)}')

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -814,9 +814,6 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
         log_prefix = "| " * len(path)
         log.debug("%sParser @ %d", log_prefix, len(path))
 
-        def _escape(text):
-            return text.replace('"', r"\"")
-
         for optional in cparser._get_optional_actions():
             log.debug("%s| Optional: %s", log_prefix, optional.dest)
 
@@ -834,9 +831,9 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                     cond_level = f"; and not __fish_seen_subcommand_from {same_level}"
 
                 cond = '; and '.join(cond_path) + cond_level
-                output.append(f"-n \"{cond}\"")
+                output.append(f'-n "{cond}"')
             else:
-                output.append("-n \"__fish_use_subcommand\"")
+                output.append('-n "__fish_use_subcommand"')
 
             for optional_str in optional.option_strings:
                 log.debug("%s| | %s", log_prefix, optional_str)
@@ -854,14 +851,14 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
 
             # Offer the different choices
             if optional.choices:
-                output.append(f"-r -a \"{' '.join(map(str, optional.choices))}\"")
+                output.append(f'-r -a "{join(map(str, optional.choices))}"')
             elif hasattr(optional, "complete"):
                 complete_fn = complete2pattern(optional.complete, 'fish', choice_type2fn)
                 if complete_fn:
-                    output.append(f"-r -a \"{complete_fn}\"")
+                    output.append(f'-r -a "{complete_fn}"')
 
             if optional.help:
-                output.append(f"-d \"{_escape(optional.help)}\"")
+                output.append(f'-d {quote(optional.help)}')
 
             completions.append(' '.join(output))
 
@@ -891,16 +888,16 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                             cond_level = f"; and not __fish_seen_subcommand_from {same_level}"
 
                         cond = '; and '.join(cond_path) + cond_level
-                        output.append(f"-n \"{cond}\"")
+                        output.append(f'-n "{cond}"')
                     else:
-                        output.append("-n \"__fish_use_subcommand\"")
+                        output.append('-n "__fish_use_subcommand"')
 
                     output.append("-f")
                     output.append(f"-a {subcmd}")
 
                     if subparser.description:
                         desc = subparser.description.strip().split("\n")[0]
-                        output.append(f'-d "{quote(desc)}"')
+                        output.append(f'-d {quote(desc)}')
 
                     completions.append(' '.join(output))
 
@@ -913,16 +910,16 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
 
                 if len(path) > 0:
                     cond = '; and '.join([f"__fish_seen_subcommand_from {cmd}" for cmd in path])
-                    output.append(f"-n \"{cond}\"")
+                    output.append(f'-n "{cond}"')
                 else:
-                    output.append("-n \"__fish_use_subcommand\"")
+                    output.append('-n "__fish_use_subcommand"')
 
                 # Allow file propositions specifically for this argument
                 output.append("-F")
 
                 if positional.help:
                     desc = positional.help.strip().split("\n")[0]
-                    output.append(f'-d "{quote(desc)}"')
+                    output.append(f'-d {quote(desc)}')
 
                 completions.append(' '.join(output))
 

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -867,6 +867,10 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                     recurse_parser(subparser, path + [subcmd], same_level_without_current)
             else:                                    # Simple argument (file, name...)
                 output = start_output(path, "")
+
+                # NOTE/caveat: positional argument order is ignored
+                output.extend(get_specials(positional))
+
                 if positional.help:
                     desc = positional.help.strip().split("\n")[0]
                     output.append(f'-d {quote(desc)}')

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -788,6 +788,8 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
 
     root_prefix:
       ignored (fish has no support for functions)
+
+    See `complete` for other arguments.
     """
 
     prog = parser.prog
@@ -800,7 +802,7 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
     if choice_functions:
         choice_type2fn.update(choice_functions)
 
-    def recurse_parser(cparser: ArgumentParser, path: List[str], same_level: str):
+    def recurse_parser(cparser: ArgumentParser, path: list[str], same_level: str):
         """
         path:
           the list of subcommands that led to current
@@ -897,7 +899,8 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                     output.append(f"-a {subcmd}")
 
                     if subparser.description:
-                        output.append(f"-d \"{_escape(subparser.description.split('\n')[0])}\"")
+                        desc = subparser.description.strip().split("\n")[0]
+                        output.append(f'-d "{quote(desc)}"')
 
                     completions.append(' '.join(output))
 
@@ -918,7 +921,8 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                 output.append("-F")
 
                 if positional.help:
-                    output.append(f"-d \"{_escape(positional.help.split('\n')[0])}\"")
+                    desc = positional.help.strip().split("\n")[0]
+                    output.append(f'-d "{quote(desc)}"')
 
                 completions.append(' '.join(output))
 

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -25,8 +25,10 @@ log = logging.getLogger(__name__)
 SUPPORTED_SHELLS: list[str] = []
 _SUPPORTED_COMPLETERS: dict[str, Callable] = {}
 CHOICE_FUNCTIONS: dict[str, dict[str, str]] = {
-    "file": {"bash": "_shtab_compgen_files", "zsh": "_files", "tcsh": "f"},
-    "directory": {"bash": "_shtab_compgen_dirs", "zsh": "_files -/", "tcsh": "d"}}
+    "file": {"bash": "_shtab_compgen_files", "zsh": "_files", "tcsh": "f", "fish": ""},
+    "directory": {
+        "bash": "_shtab_compgen_dirs", "zsh": "_files -/", "tcsh": "d",
+        "fish": "__fish_complete_directories"}}
 FILE = CHOICE_FUNCTIONS["file"]
 DIRECTORY = DIR = CHOICE_FUNCTIONS["directory"]
 FLAG_OPTION = (
@@ -777,6 +779,168 @@ complete ${prog} \\
         prog=parser.prog, optionals_double_str=' '.join(sorted(optionals_double)),
         optionals_single_str=' '.join(sorted(optionals_single)),
         optionals_special_str=' \\\n        '.join(specials))
+
+
+@mark_completer("fish")
+def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
+    """
+    Return fish syntax autocompletion script.
+
+    root_prefix:
+      ignored (fish has no support for functions)
+    """
+
+    prog = parser.prog
+    completions = []
+
+    if preamble:
+        preamble = f"# Custom Preamble\n{preamble}\n# End Custom Preamble\n"
+
+    choice_type2fn = {k: v["fish"] for k, v in CHOICE_FUNCTIONS.items()}
+    if choice_functions:
+        choice_type2fn.update(choice_functions)
+
+    def recurse_parser(cparser: ArgumentParser, path: List[str], same_level: str):
+        """
+        path:
+          the list of subcommands that led to current
+
+        same_level:
+          a space separated list of other subcommands available on the same level
+          must not contain the current subcommand
+        """
+        log_prefix = "| " * len(path)
+        log.debug("%sParser @ %d", log_prefix, len(path))
+
+        def _escape(text):
+            return text.replace('"', r"\"")
+
+        for optional in cparser._get_optional_actions():
+            log.debug("%s| Optional: %s", log_prefix, optional.dest)
+
+            if optional.help == SUPPRESS:
+                continue
+
+            output = ["complete", "-c", prog]
+
+            if len(path) > 0:
+                # Show option only if in subcommand path, and no subcommand on other level is shown
+                cond_path = [f"__fish_seen_subcommand_from {cmd}" for cmd in path]
+
+                cond_level = ""
+                if same_level != "":
+                    cond_level = f"; and not __fish_seen_subcommand_from {same_level}"
+
+                cond = '; and '.join(cond_path) + cond_level
+                output.append(f"-n \"{cond}\"")
+            else:
+                output.append("-n \"__fish_use_subcommand\"")
+
+            for optional_str in optional.option_strings:
+                log.debug("%s| | %s", log_prefix, optional_str)
+                if optional_str.startswith("--"):
+                    output.append(f"-l {optional_str[2:]}")
+                elif optional_str.startswith("-"):
+                    output.append(f"-s {optional_str[1:]}")
+
+            # Disable file and directories completion if no type is provided
+            # (by default, Fish always suggests files and directories)
+            if optional.type is None:
+                output.append("-f")
+            else:
+                output.append("-F")
+
+            # Offer the different choices
+            if hasattr(optional, "complete"):
+                complete_fn = complete2pattern(optional.complete, 'fish', choice_type2fn)
+                if complete_fn:
+                    output.append(f"-r -a \"{complete_fn}\"")
+            elif optional.choices and isinstance(optional.choices[0], Choice):
+                complete_pattern = choice_type2fn[optional.choices[0].type]
+                output.append(f"-r -a \"{complete_pattern}\"")
+            elif optional.choices:
+                output.append(f"-r -a \"{' '.join(map(str, optional.choices))}\"")
+
+            if optional.help:
+                output.append(f"-d \"{_escape(optional.help)}\"")
+
+            completions.append(' '.join(output))
+
+        for positional in cparser._get_positional_actions():
+            if positional.help == SUPPRESS:
+                continue
+
+            log.debug("%s| Positional #%d: %s", log_prefix, len(path) + 1, positional.dest)
+
+            if isinstance(positional.choices, dict):
+                # Positional subcommand
+                public = get_public_subcommands(positional)
+                same_level = ' '.join(public)
+
+                for subcmd, subparser in positional.choices.items():
+                    if subcmd not in public:
+                        continue
+
+                    log.debug("%s| | SubParser: %s", log_prefix, subcmd)
+                    output = ["complete", "-c", prog]
+
+                    if len(path) > 0:
+                        cond_path = [f"__fish_seen_subcommand_from {cmd}" for cmd in path]
+
+                        cond_level = ""
+                        if same_level != "":
+                            cond_level = f"; and not __fish_seen_subcommand_from {same_level}"
+
+                        cond = '; and '.join(cond_path) + cond_level
+                        output.append(f"-n \"{cond}\"")
+                    else:
+                        output.append("-n \"__fish_use_subcommand\"")
+
+                    output.append("-f")
+                    output.append(f"-a {subcmd}")
+
+                    if subparser.description:
+                        output.append(f"-d \"{_escape(subparser.description.split('\n')[0])}\"")
+
+                    completions.append(' '.join(output))
+
+                    same_level_without_current = ' '.join(filter(lambda c: c != subcmd, public))
+                    recurse_parser(subparser, path + [subcmd], same_level_without_current)
+
+            else:
+                # Simple argument (file, name...)
+                output = ["complete", "-c", prog]
+
+                if len(path) > 0:
+                    cond = '; and '.join([f"__fish_seen_subcommand_from {cmd}" for cmd in path])
+                    output.append(f"-n \"{cond}\"")
+                else:
+                    output.append("-n \"__fish_use_subcommand\"")
+
+                # Allow file propositions specifically for this argument
+                output.append("-F")
+
+                if positional.help:
+                    output.append(f"-d \"{_escape(positional.help.split('\n')[0])}\"")
+
+                completions.append(' '.join(output))
+
+    recurse_parser(parser, [], "")
+
+    return Template("""\
+# AUTOMATICALLY GENERATED by `shtab`
+
+${preamble}
+
+complete -c ${prog} -e
+complete -c ${prog} -f
+
+${completions}
+""").safe_substitute(
+        preamble=preamble,
+        prog=parser.prog,
+        completions='\n'.join(completions),
+    )
 
 
 def complete(parser: ArgumentParser, shell: str = "bash", root_prefix: Opt[str] = None,

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -851,15 +851,12 @@ def complete_fish(parser, root_prefix=None, preamble="", choice_functions=None):
                 output.append("-F")
 
             # Offer the different choices
-            if hasattr(optional, "complete"):
+            if optional.choices:
+                output.append(f"-r -a \"{' '.join(map(str, optional.choices))}\"")
+            elif hasattr(optional, "complete"):
                 complete_fn = complete2pattern(optional.complete, 'fish', choice_type2fn)
                 if complete_fn:
                     output.append(f"-r -a \"{complete_fn}\"")
-            elif optional.choices and isinstance(optional.choices[0], Choice):
-                complete_pattern = choice_type2fn[optional.choices[0].type]
-                output.append(f"-r -a \"{complete_pattern}\"")
-            elif optional.choices:
-                output.append(f"-r -a \"{' '.join(map(str, optional.choices))}\"")
 
             if optional.help:
                 output.append(f"-d \"{_escape(optional.help)}\"")

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -141,19 +141,19 @@ def test_prog_scripts(shell, caplog, capsys):
         start = 'complete -c script.py -n "__fish_use_subcommand"'
         assert script_py == [
             'complete -c script.py -e', 'complete -c script.py -f',
-            f"{start} -s h -l help -f -d 'show this help message and exit'",
-            f"{start} -l version -f -d 'show program'\"'\"'s version number and exit'",
-            f'{start} -s s -l shell -f -rka "bash zsh tcsh fish"',
-            f"{start} -s o -l output -F -d 'output file (- for stdout)'",
-            f"{start} -l prefix -f -d 'prepended to generated functions to avoid clashes'",
-            f"{start} -l preamble -f -d 'prepended to generated script'",
-            f"{start} -l prog -f -d 'custom program name (overrides `parser.prog`)'",
-            f"{start} -s u -l error-unimportable -f -d"
+            f"{start} -s h -l help -d 'show this help message and exit'",
+            f"{start} -l version -d 'show program'\"'\"'s version number and exit'",
+            f'{start} -s s -l shell -rka "bash zsh tcsh fish"',
+            f"{start} -s o -l output -d 'output file (- for stdout)'",
+            f"{start} -l prefix -d 'prepended to generated functions to avoid clashes'",
+            f"{start} -l preamble -d 'prepended to generated script'",
+            f"{start} -l prog -d 'custom program name (overrides `parser.prog`)'",
+            f"{start} -s u -l error-unimportable -d"
             " 'raise errors if `parser` is not found in $PYTHONPATH'",
-            f"{start} -l verbose -f -d 'Log debug information'",
-            f'{start} -l print-own-completion -f -rka "bash zsh tcsh fish" -d'
+            f"{start} -l verbose -d 'Log debug information'",
+            f'{start} -l print-own-completion -rka "bash zsh tcsh fish" -d'
             " 'print shtab'\"'\"'s own completion'",
-            f"{start} -F -d 'importable parser (or function returning parser)'"]
+            f"{start} -d 'importable parser (or function returning parser)'"]
     else:
         raise NotImplementedError(shell)
 

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -143,7 +143,7 @@ def test_prog_scripts(shell, caplog, capsys):
             'complete -c script.py -e', 'complete -c script.py -f',
             f"{start} -s h -l help -f -d 'show this help message and exit'",
             f"{start} -l version -f -d 'show program'\"'\"'s version number and exit'",
-            f'{start} -s s -l shell -f -r -a "bash zsh tcsh fish"',
+            f'{start} -s s -l shell -f -rka "bash zsh tcsh fish"',
             f"{start} -s o -l output -F -d 'output file (- for stdout)'",
             f"{start} -l prefix -f -d 'prepended to generated functions to avoid clashes'",
             f"{start} -l preamble -f -d 'prepended to generated script'",
@@ -151,7 +151,7 @@ def test_prog_scripts(shell, caplog, capsys):
             f"{start} -s u -l error-unimportable -f -d"
             " 'raise errors if `parser` is not found in $PYTHONPATH'",
             f"{start} -l verbose -f -d 'Log debug information'",
-            f'{start} -l print-own-completion -f -r -a "bash zsh tcsh fish" -d'
+            f'{start} -l print-own-completion -f -rka "bash zsh tcsh fish" -d'
             " 'print shtab'\"'\"'s own completion'",
             f"{start} -F -d 'importable parser (or function returning parser)'"]
     else:

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -139,21 +139,21 @@ def test_prog_scripts(shell, caplog, capsys):
         assert script_py == ["complete script.py \\"]
     elif shell == "fish":
         start = 'complete -c script.py -n "__fish_use_subcommand"'
-        help_unimportable = '"raise errors if `parser` is not found in $PYTHONPATH"'
-        help_completion = '"bash zsh tcsh fish" -d "print shtab\'s own completion"'
         assert script_py == [
             'complete -c script.py -e', 'complete -c script.py -f',
-            f'{start} -s h -l help -f -d "show this help message and exit"',
-            f'{start} -l version -f -d "show program\'s version number and exit"',
+            f"{start} -s h -l help -f -d 'show this help message and exit'",
+            f"{start} -l version -f -d 'show program'\"'\"'s version number and exit'",
             f'{start} -s s -l shell -f -r -a "bash zsh tcsh fish"',
-            f'{start} -s o -l output -F -d "output file (- for stdout)"',
-            f'{start} -l prefix -f -d "prepended to generated functions to avoid clashes"',
-            f'{start} -l preamble -f -d "prepended to generated script"',
-            f'{start} -l prog -f -d "custom program name (overrides `parser.prog`)"',
-            f'{start} -s u -l error-unimportable -f -d {help_unimportable}',
-            f'{start} -l verbose -f -d "Log debug information"',
-            f'{start} -l print-own-completion -f -r -a {help_completion}',
-            f"{start} -F -d \"'importable parser (or function returning parser)'\""]
+            f"{start} -s o -l output -F -d 'output file (- for stdout)'",
+            f"{start} -l prefix -f -d 'prepended to generated functions to avoid clashes'",
+            f"{start} -l preamble -f -d 'prepended to generated script'",
+            f"{start} -l prog -f -d 'custom program name (overrides `parser.prog`)'",
+            f"{start} -s u -l error-unimportable -f -d"
+            " 'raise errors if `parser` is not found in $PYTHONPATH'",
+            f"{start} -l verbose -f -d 'Log debug information'",
+            f'{start} -l print-own-completion -f -r -a "bash zsh tcsh fish" -d'
+            " 'print shtab'\"'\"'s own completion'",
+            f"{start} -F -d 'importable parser (or function returning parser)'"]
     else:
         raise NotImplementedError(shell)
 

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -153,7 +153,7 @@ def test_prog_scripts(shell, caplog, capsys):
             f'{start} -s u -l error-unimportable -f -d {help_unimportable}',
             f'{start} -l verbose -f -d "Log debug information"',
             f'{start} -l print-own-completion -f -r -a {help_completion}',
-            f'{start} -F -d "importable parser (or function returning parser)"']
+            f"{start} -F -d \"'importable parser (or function returning parser)'\""]
     else:
         raise NotImplementedError(shell)
 

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -74,7 +74,7 @@ def test_main_self_completion(shell, caplog, capsys):
     assert not captured.err
     expected = {
         "bash": "complete -o filenames -F _shtab_shtab shtab", "zsh": "_shtab_shtab_commands()",
-        "tcsh": "complete shtab"}
+        "tcsh": "complete shtab", "fish": "complete -c shtab"}
     assert expected[shell] in captured.out
 
     assert not caplog.record_tuples
@@ -94,7 +94,7 @@ def test_main_output_path(shell, caplog, capsys, change_dir, output):
     assert not captured.err
     expected = {
         "bash": "complete -o filenames -F _shtab_shtab shtab", "zsh": "_shtab_shtab_commands()",
-        "tcsh": "complete shtab"}
+        "tcsh": "complete shtab", "fish": "complete -c shtab"}
 
     if output in ("-", "stdout"):
         assert expected[shell] in captured.out
@@ -137,6 +137,23 @@ def test_prog_scripts(shell, caplog, capsys):
             "compdef _shtab_shtab -N script.py"]
     elif shell == "tcsh":
         assert script_py == ["complete script.py \\"]
+    elif shell == "fish":
+        start = 'complete -c script.py -n "__fish_use_subcommand"'
+        help_unimportable = '"raise errors if `parser` is not found in $PYTHONPATH"'
+        help_completion = '"bash zsh tcsh fish" -d "print shtab\'s own completion"'
+        assert script_py == [
+            'complete -c script.py -e', 'complete -c script.py -f',
+            f'{start} -s h -l help -f -d "show this help message and exit"',
+            f'{start} -l version -f -d "show program\'s version number and exit"',
+            f'{start} -s s -l shell -f -r -a "bash zsh tcsh fish"',
+            f'{start} -s o -l output -F -d "output file (- for stdout)"',
+            f'{start} -l prefix -f -d "prepended to generated functions to avoid clashes"',
+            f'{start} -l preamble -f -d "prepended to generated script"',
+            f'{start} -l prog -f -d "custom program name (overrides `parser.prog`)"',
+            f'{start} -s u -l error-unimportable -f -d {help_unimportable}',
+            f'{start} -l verbose -f -d "Log debug information"',
+            f'{start} -l print-own-completion -f -r -a {help_completion}',
+            f'{start} -F -d "importable parser (or function returning parser)"']
     else:
         raise NotImplementedError(shell)
 


### PR DESCRIPTION
Closes #195.
Closes #174.
Closes #134.

This implementation uses `not __fish_seen_subcommand_from` to support subcommands and nested commands. Contrary to #195, this isn't limited to 3 levels deep. One limitation from this implementation is if a tool has subcommands `a b` and `b a`, then the sub-subcommands of both will be mixed.