### PR TITLE
org migrate

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: [casperdcl, tqdm]
+thanks_dev: u/gh/tqdm
+custom: https://tqdm.github.io/merch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python: [3.9, 3.14]
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
       with: {fetch-depth: 0}
     - uses: actions/setup-python@v6
       with:
@@ -21,7 +21,7 @@ jobs:
     - name: Install
       run: pip install -U -e .[dev]
     - run: pytest
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
   deploy:
@@ -33,12 +33,14 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-      with: {fetch-depth: 0}
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GH_TOKEN || github.token }}
     - uses: actions/setup-python@v6
       with: {python-version: '3.x'}
     - id: dist
-      uses: casperdcl/deploy-pypi@v2
+      uses: casperdcl/deploy-pypi@v3
       with:
         build: true
         requirements: 'build twine packaging>=24.2' # https://github.com/pypa/twine/issues/1216

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,5 +65,5 @@ jobs:
         history: false
         dir: dist/site
         nojekyll: true
-        name: Olivaw[bot]
-        email: 64868532+iterative-olivaw@users.noreply.github.com
+        name: tqdm[bot]
+        email: 68520887+tqdm-bot@users.noreply.github.com

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 __pycache__/
 
 # Packages
-/MANIFEST.in
 /*.egg*/
-/shtab/_dist_ver.py
 /build/
 /dist/
 /docs/build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     - flake8-pyproject
     - flake8-string-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.18.2
+  rev: v2.1.0
   hooks:
   - id: mypy
     additional_dependencies: [types-setuptools]
@@ -51,7 +51,7 @@ repos:
     args: [-i]
     additional_dependencies: [toml]
 - repo: https://github.com/PyCQA/isort
-  rev: 7.0.0
+  rev: 9.0.0a3
   hooks:
   - id: isort
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,14 @@ repos:
     entry: TODO
     types: [text]
     exclude: ^(.pre-commit-config.yaml|.github/workflows/test.yml)$
+  - id: pytest
+    name: pytest quiet
+    language: python
+    entry: pytest
+    args: [-qq]
+    types: [python]
+    pass_filenames: false
+    additional_dependencies: [pytest-cov, pytest-timeout]
 - repo: https://github.com/PyCQA/flake8
   rev: 7.3.0
   hooks:
@@ -38,7 +46,11 @@ repos:
     - flake8-debugger
     - flake8-isort
     - flake8-pyproject
-    - flake8-string-format
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.21.2
+  hooks:
+  - id: pyupgrade
+    args: [--py39-plus]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v2.1.0
   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,5 +42,5 @@ The generated shell code itself is also meant to be readable.
 
 Tests and deployment are handled automatically by continuous integration. Simply
 tag a commit `v{major}.{minor}.{patch}` and wait for a draft release to appear
-at <https://github.com/iterative/shtab/releases>. Tidy up the draft's
+at <https://github.com/tqdm/shtab/releases>. Tidy up the draft's
 description before publishing it.

--- a/LICENCE
+++ b/LICENCE
@@ -1,13 +1,9 @@
-Copyright 2020-2025 Casper da Costa-Luis
+Copyright 2020-2026 Casper da Costa-Luis
 
-Licensed under the Apache Licence, Version 2.0 (the "Licence");
-you may not use this project except in compliance with the Licence.
-You may obtain a copy of the Licence at
+Mozilla Public Licence (MPL) v. 2.0 - Exhibit A
+-----------------------------------------------
 
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the Licence is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the Licence for the specific language governing permissions and
-limitations under the Licence.
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0.
+If a copy of the MPL was not distributed with this project,
+You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/README.rst
+++ b/README.rst
@@ -45,19 +45,19 @@ Choose one of:
 - ``pip install shtab``, or
 - ``conda install -c conda-forge shtab``
 
-See `operating system-specific instructions in the docs <https://docs.iterative.ai/shtab/#installation>`_.
+See `operating system-specific instructions in the docs <https://tqdm.github.io/shtab/#installation>`_.
 
 Usage
 -----
 
 There are two ways of using ``shtab``:
 
-- `CLI Usage <https://docs.iterative.ai/shtab/use/#cli-usage>`_: ``shtab``'s own CLI interface for external applications
+- `CLI Usage <https://tqdm.github.io/shtab/use/#cli-usage>`_: ``shtab``'s own CLI interface for external applications
 
   - may not require any code modifications whatsoever
   - end-users execute ``shtab your_cli_app.your_parser_object``
 
-- `Library Usage <https://docs.iterative.ai/shtab/use/#library-usage>`_: as a library integrated into your CLI application
+- `Library Usage <https://tqdm.github.io/shtab/use/#library-usage>`_: as a library integrated into your CLI application
 
   - adds a couple of lines to your application
   - argument mode: end-users execute ``your_cli_app --print-completion {bash,zsh,tcsh}``
@@ -66,12 +66,12 @@ There are two ways of using ``shtab``:
 Examples
 --------
 
-See `the docs for usage examples <https://docs.iterative.ai/shtab/use/#main.py>`_.
+See `the docs for usage examples <https://tqdm.github.io/shtab/use/#main.py>`_.
 
 FAQs
 ----
 
-Not working? Check out `frequently asked questions <https://docs.iterative.ai/shtab/#faqs>`_.
+Not working? Check out `frequently asked questions <https://tqdm.github.io/shtab/#faqs>`_.
 
 Alternatives
 ------------
@@ -95,23 +95,23 @@ Alternatives
 Contributions
 -------------
 
-Please do open `issues <https://github.com/iterative/shtab/issues>`_ & `pull requests <https://github.com/iterative/shtab/pulls>`_! Some ideas:
+Please do open `issues <https://github.com/tqdm/shtab/issues>`_ & `pull requests <https://github.com/tqdm/shtab/pulls>`_! Some ideas:
 
-- support ``fish`` (`#174 <https://github.com/iterative/shtab/pull/174>`_)
+- support ``fish`` (`#174 <https://github.com/tqdm/shtab/pull/174>`_)
 - support ``powershell``
 
 See
-`CONTRIBUTING.md <https://github.com/iterative/shtab/tree/main/CONTRIBUTING.md>`_
+`CONTRIBUTING.md <https://github.com/tqdm/shtab/tree/main/CONTRIBUTING.md>`_
 for more guidance.
 
 |Hits|
 
-.. |Logo| image:: https://github.com/iterative/shtab/raw/main/meta/logo.png
-.. |Tests| image:: https://img.shields.io/github/actions/workflow/status/iterative/shtab/test.yml?logo=github&label=tests
-   :target: https://github.com/iterative/shtab/actions
+.. |Logo| image:: https://github.com/tqdm/shtab/raw/main/meta/logo.png
+.. |Tests| image:: https://img.shields.io/github/actions/workflow/status/tqdm/shtab/test.yml?logo=github&label=tests
+   :target: https://github.com/tqdm/shtab/actions
    :alt: Tests
-.. |Coverage| image:: https://codecov.io/gh/iterative/shtab/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/iterative/shtab
+.. |Coverage| image:: https://codecov.io/gh/tqdm/shtab/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/tqdm/shtab
    :alt: Coverage
 .. |Conda| image:: https://img.shields.io/conda/v/conda-forge/shtab.svg?label=conda&logo=conda-forge
    :target: https://anaconda.org/conda-forge/shtab
@@ -122,6 +122,6 @@ for more guidance.
 .. |PyPI-Downloads| image:: https://img.shields.io/pypi/dm/shtab.svg?label=pypi%20downloads&logo=PyPI&logoColor=white
    :target: https://pepy.tech/project/shtab
    :alt: Downloads
-.. |Hits| image:: https://cgi.cdcl.ml/hits?q=shtab&style=social&r=https://github.com/iterative/shtab&a=hidden
-   :target: https://cgi.cdcl.ml/hits?q=shtab&a=plot&r=https://github.com/iterative/shtab&style=social
+.. |Hits| image:: https://cgi.cdcl.ml/hits?q=shtab&style=social&r=https://github.com/tqdm/shtab&a=hidden
+   :target: https://cgi.cdcl.ml/hits?q=shtab&a=plot&r=https://github.com/tqdm/shtab&style=social
    :alt: Hits

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-![shtab](https://static.iterative.ai/img/shtab/banner.png)
+![shtab](https://tqdm.github.io/img/shtab-banner.png)
 
 [![Downloads](https://img.shields.io/pypi/dm/shtab.svg?label=pypi%20downloads&logo=PyPI&logoColor=white)](https://pepy.tech/project/shtab)
-[![Tests](https://img.shields.io/github/actions/workflow/status/iterative/shtab/test.yml?logo=github&label=tests)](https://github.com/iterative/shtab/actions)
-[![Coverage](https://codecov.io/gh/iterative/shtab/branch/main/graph/badge.svg)](https://codecov.io/gh/iterative/shtab)
+[![Tests](https://img.shields.io/github/actions/workflow/status/tqdm/shtab/test.yml?logo=github&label=tests)](https://github.com/tqdm/shtab/actions)
+[![Coverage](https://codecov.io/gh/tqdm/shtab/branch/main/graph/badge.svg)](https://codecov.io/gh/tqdm/shtab)
 [![PyPI](https://img.shields.io/pypi/v/shtab.svg?label=pip&logo=PyPI&logoColor=white)](https://pypi.org/project/shtab)
 [![conda-forge](https://img.shields.io/conda/v/conda-forge/shtab.svg?label=conda&logo=conda-forge)](https://anaconda.org/conda-forge/shtab)
 
@@ -109,14 +109,14 @@ application. Use `-u, --error-unimportable` to noisily complain.
 
 Please do open [issues][GH-issue] & [pull requests][GH-pr]! Some ideas:
 
-- support `fish` ([#174](https://github.com/iterative/shtab/pull/174))
+- support `fish` ([#174](https://github.com/tqdm/shtab/pull/174))
 - support `powershell`
 
 See
-[CONTRIBUTING.md](https://github.com/iterative/shtab/tree/main/CONTRIBUTING.md)
+[CONTRIBUTING.md](https://github.com/tqdm/shtab/tree/main/CONTRIBUTING.md)
 for more guidance.
 
-[![Hits](https://cgi.cdcl.ml/hits?q=shtab&style=social&r=https://github.com/iterative/shtab&a=hidden)](https://cgi.cdcl.ml/hits?q=shtab&a=plot&r=https://github.com/iterative/shtab&style=social)
+[![Hits](https://cgi.cdcl.ml/hits?q=shtab&style=social&r=https://github.com/tqdm/shtab&a=hidden)](https://cgi.cdcl.ml/hits?q=shtab&a=plot&r=https://github.com/tqdm/shtab&style=social)
 
-[GH-issue]: https://github.com/iterative/shtab/issues
-[GH-pr]: https://github.com/iterative/shtab/pulls
+[GH-issue]: https://github.com/tqdm/shtab/issues
+[GH-pr]: https://github.com/tqdm/shtab/pulls

--- a/docs/pydoc-markdown.yml
+++ b/docs/pydoc-markdown.yml
@@ -7,13 +7,13 @@ processors:
 - type: crossref
 hooks:
   pre-render:
-  - sed 's#](./#](https://github.com/iterative/shtab/tree/main/#g' ../CONTRIBUTING.md > contributing.md
+  - sed 's#](./#](https://github.com/tqdm/shtab/tree/main/#g' ../CONTRIBUTING.md > contributing.md
 renderer:
   type: mkdocs
   markdown:
     source_linker:
       type: github
-      repo: iterative/shtab
+      repo: tqdm/shtab
       root: ..
     source_position: before signature
     source_format: |
@@ -33,11 +33,11 @@ renderer:
   - title: External Links
     children:
     - title: Source Code
-      href: https://github.com/iterative/shtab
+      href: https://github.com/tqdm/shtab
     - title: Changelog
-      href: https://github.com/iterative/shtab/releases
+      href: https://github.com/tqdm/shtab/releases
     - title: Issues
-      href: https://github.com/iterative/shtab/issues?q=
+      href: https://github.com/tqdm/shtab/issues?q=
   - title: Contributing
     name: contributing
     source: contributing.md
@@ -47,10 +47,10 @@ renderer:
   mkdocs_config:
     site_name: shtab documentation
     site_description: Automagic shell tab completion for Python CLI applications
-    site_url: https://docs.iterative.ai/shtab/
-    site_author: Iterative
-    repo_name: iterative/shtab
-    repo_url: https://github.com/iterative/shtab
+    site_url: https://tqdm.github.io/shtab/
+    site_author: Casper da Costa-Luis
+    repo_name: tqdm/shtab
+    repo_url: https://github.com/tqdm/shtab
     copyright: |
       &copy; Casper da Costa-Luis <a href="https://github.com/casperdcl">@casperdcl</a> 2021
 
@@ -58,8 +58,8 @@ renderer:
       generator: false
     theme:
       name: material
-      logo: https://github.com/iterative/shtab/raw/main/meta/logo.png
-      favicon: https://github.com/iterative/shtab/raw/main/meta/logo.png
+      logo: https://github.com/tqdm/shtab/raw/main/meta/logo.png
+      favicon: https://github.com/tqdm/shtab/raw/main/meta/logo.png
       features: [content.tabs.link]
       palette:
       - scheme: default

--- a/docs/pydoc_markdown_shtab.py
+++ b/docs/pydoc_markdown_shtab.py
@@ -12,6 +12,6 @@ class ShtabProcessor(PydocmdProcessor):
                                         flags=re.M)
         # fix code cross-references
         node.docstring.content = re.sub(r"<../(\S+)>",
-                                        r"[\1](https://github.com/iterative/shtab/tree/main/\1)",
+                                        r"[\1](https://github.com/tqdm/shtab/tree/main/\1)",
                                         node.docstring.content, flags=re.M)
         return super()._process(node)

--- a/docs/use.md
+++ b/docs/use.md
@@ -99,7 +99,7 @@ Below are various examples of enabling `shtab`'s own tab completion scripts.
     ```
 
 !!! tip
-    See the [examples/](https://github.com/iterative/shtab/tree/main/examples)
+    See the [examples/](https://github.com/tqdm/shtab/tree/main/examples)
     folder for more.
 
 Any existing `argparse`-based scripts should be supported with minimal effort.
@@ -148,14 +148,14 @@ Assuming this code example is installed in `MY_PROG.command.main`, simply run:
 ## Library Usage
 
 !!! tip
-    See the [examples/](https://github.com/iterative/shtab/tree/main/examples)
+    See the [examples/](https://github.com/tqdm/shtab/tree/main/examples)
     folder for more.
 
 Complex projects with subparsers and custom completions for paths matching
 certain patterns (e.g. `--file=*.txt`) are fully supported (see
-[examples/customcomplete.py](https://github.com/iterative/shtab/tree/main/examples/customcomplete.py)
+[examples/customcomplete.py](https://github.com/tqdm/shtab/tree/main/examples/customcomplete.py)
 or even
-[iterative/dvc:commands/completion.py](https://github.com/iterative/dvc/blob/main/dvc/commands/completion.py)
+[treeverse/dvc:commands/completion.py](https://github.com/treeverse/dvc/blob/main/dvc/commands/completion.py)
 for example).
 
 Add direct support to scripts for a little more configurability:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,6 @@ requires = ["setuptools>=77", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-write_to = "shtab/_dist_ver.py"
-write_to_template = "__version__ = '{version}'\n"
 
 [tool.setuptools.packages.find]
 exclude = ["docs", "tests", "examples"]
@@ -26,7 +24,7 @@ description = "Automagic shell tab completion for Python CLI applications"
 readme = "README.rst"
 requires-python = ">=3.9"
 keywords = ["tab", "complete", "completion", "shell", "bash", "zsh", "argparse"]
-license = "Apache-2.0"
+license = {text = "MPL-2.0"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -117,3 +115,8 @@ log_level = "DEBUG"
 python_files = ["test_*.py"]
 testpaths = ["tests"]
 addopts = "-v --tb=short -rxs -W=error --durations=0 --cov=shtab --cov-report=term-missing --cov-report=xml"
+
+[tool.coverage.run]
+branch = true
+[tool.coverage.report]
+show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,15 +13,15 @@ exclude = ["docs", "tests", "examples"]
 "*" = ["logo.png"]
 
 [project.urls]
-documentation = "https://docs.iterative.ai/shtab"
-repository = "https://github.com/iterative/shtab"
-changelog = "https://github.com/iterative/shtab/releases"
+documentation = "https://tqdm.github.io/shtab"
+repository = "https://github.com/tqdm/shtab"
+changelog = "https://github.com/tqdm/shtab/releases"
 
 [project]
 name = "shtab"
 dynamic = ["version"]
 authors = [{name = "Casper da Costa-Luis", email = "casper.dcl@physics.org"}]
-maintainers = [{name = "Iterative", email = "support@iterative.ai"}]
+maintainers = [{name = "tqdm developers", email = "devs@tqdm.ml"}]
 description = "Automagic shell tab completion for Python CLI applications"
 readme = "README.rst"
 requires-python = ">=3.9"

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -16,28 +16,25 @@ from argparse import (
 )
 from collections import defaultdict
 from functools import total_ordering
+from importlib.metadata import PackageNotFoundError, version
 from itertools import starmap
 from string import Template
-from typing import Any, Dict, List
+from typing import Any, Callable
 from typing import Optional as Opt
 from typing import Union
 
 # version detector. Precedence: installed dist, git, 'UNKNOWN'
 try:
-    from ._dist_ver import __version__
-except ImportError:
-    try:
-        from setuptools_scm import get_version
+    __version__ = version('shtab')
+except PackageNotFoundError:
+    __version__ = "UNKNOWN"
 
-        __version__ = get_version(root="..", relative_to=__file__)
-    except (ImportError, LookupError):
-        __version__ = "UNKNOWN"
 __all__ = ["complete", "add_argument_to", "SUPPORTED_SHELLS", "FILE", "DIRECTORY", "DIR"]
 log = logging.getLogger(__name__)
 
-SUPPORTED_SHELLS: List[str] = []
-_SUPPORTED_COMPLETERS = {}
-CHOICE_FUNCTIONS: Dict[str, Dict[str, str]] = {
+SUPPORTED_SHELLS: list[str] = []
+_SUPPORTED_COMPLETERS: dict[str, Callable] = {}
+CHOICE_FUNCTIONS: dict[str, dict[str, str]] = {
     "file": {"bash": "_shtab_compgen_files", "zsh": "_files", "tcsh": "f"},
     "directory": {"bash": "_shtab_compgen_dirs", "zsh": "_files -/", "tcsh": "d"}}
 FILE = CHOICE_FUNCTIONS["file"]
@@ -801,7 +798,7 @@ complete ${prog} \\
 
 
 def complete(parser: ArgumentParser, shell: str = "bash", root_prefix: Opt[str] = None,
-             preamble: Union[str, Dict[str, str]] = "", choice_functions: Opt[Any] = None) -> str:
+             preamble: Union[str, dict[str, str]] = "", choice_functions: Opt[Any] = None) -> str:
     """
     shell:
       bash/zsh/tcsh
@@ -827,7 +824,7 @@ def complete(parser: ArgumentParser, shell: str = "bash", root_prefix: Opt[str] 
     )
 
 
-def completion_action(parent: Opt[ArgumentParser] = None, preamble: Union[str, Dict[str,
+def completion_action(parent: Opt[ArgumentParser] = None, preamble: Union[str, dict[str,
                                                                                     str]] = ""):
     class PrintCompletionAction(_ShtabPrintCompletionAction):
         def __call__(self, parser, namespace, values, option_string=None):
@@ -839,10 +836,10 @@ def completion_action(parent: Opt[ArgumentParser] = None, preamble: Union[str, D
 
 def add_argument_to(
     parser: ArgumentParser,
-    option_string: Union[str, List[str]] = "--print-completion",
+    option_string: Union[str, list[str]] = "--print-completion",
     help: str = "print shell completion script",
     parent: Opt[ArgumentParser] = None,
-    preamble: Union[str, Dict[str, str]] = "",
+    preamble: Union[str, dict[str, str]] = "",
 ):
     """
     option_string:


### PR DESCRIPTION
- docs: migrate repo org `iterative` -> `tqdm`
- CI: bump workflow actions & pre-commit hooks
- update syntax to python>=3.9
- update `setuptools-scm` usage: drop `_dist_ver.py`, use `importlib.metadata.version`