### PR TITLE
fix: add optional message colon for zsh remainder

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -509,7 +509,8 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
     def format_positional(opt, parser):
         get_help = parser._get_formatter()._expand_help
         return '"{nargs}:{help}:{pattern}"'.format(
-            nargs={ONE_OR_MORE: "(*)", ZERO_OR_MORE: "(*):", REMAINDER: "(-)*"}.get(opt.nargs, ""),
+            nargs={ONE_OR_MORE: "(*)", ZERO_OR_MORE: "(*):",
+                   REMAINDER: "(-)*:"}.get(opt.nargs, ""),
             help=escape_zsh((get_help(opt) if opt.help else opt.dest).strip().split("\n")[0]),
             pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
                 opt, "complete") else
@@ -604,7 +605,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
         return f"""\
 {prefix}() {{
   local context state line \
-curcontext="$curcontext" one_or_more='(*)' remainder='(-)*' default='*::: :->{name}'
+curcontext="$curcontext" one_or_more='(*)' remainder='(-)*:' default='*::: :->{name}'
 
   # Add default positional/remainder specs only if none exist, and only once per session
   if (( ! {prefix}_defaults_added )); then

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -134,7 +134,7 @@ def test_prog_scripts(shell, caplog, capsys):
         assert script_py == [
             "#compdef script.py", "_describe 'script.py commands' _commands",
             'local context state line curcontext="$curcontext" '
-            "one_or_more='(*)' remainder='(-)*' default='*::: :->script.py'",
+            "one_or_more='(*)' remainder='(-)*:' default='*::: :->script.py'",
             "_shtab_shtab_options+=(': :_shtab_shtab_commands' '*::: :->script.py')", "script.py)",
             "compdef _shtab_shtab -N script.py"]
     elif shell == "tcsh":
@@ -202,6 +202,19 @@ def test_custom_complete(shell, caplog):
         shell = Bash(completion)
         shell.test('"$($_shtab_test_pos_0_COMPGEN o)" = "one"')
 
+    assert not caplog.record_tuples
+
+
+def test_zsh_remainder_custom_complete_has_optional_message_colon(caplog):
+    parser = ArgumentParser(prog="test")
+    parser.add_argument("command", nargs=1).complete = {"zsh": "{_command_names -e}"}
+    parser.add_argument("args", nargs="...").complete = {"zsh": "_normal"}
+
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell="zsh")
+
+    assert '"(-)*::args:_normal"' in completion
+    assert '"(-)*:args:_normal"' not in completion
     assert not caplog.record_tuples
 
 


### PR DESCRIPTION
## Summary
- Fix zsh `argparse.REMAINDER` positional specs to include the optional-message colon (`(-)*::...`) required by `_arguments`
- Keep the generated default/remainder detection in sync with the new prefix
- Add a regression test for the `_sudo`-style custom completion case from the issue

Fixes #125

## Verification
- `pytest tests/test_shtab.py::test_zsh_remainder_custom_complete_has_optional_message_colon tests/test_shtab.py::test_prog_scripts[zsh] -q`
- `pytest -q`
- `git diff --check`
- `pre-commit run --all-files`
