### PR TITLE
fix: support non-sequence choices in zsh completion

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -473,6 +473,12 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
     def is_opt_multiline(opt):
         return isinstance(opt, OPTION_MULTI)
 
+    def choices2pattern(choices):
+        first = next(iter(choices))
+        if isinstance(first, Choice):
+            return choice_type2fn[first.type]
+        return "({})".format(" ".join(map(str, choices)))
+
     def format_optional(opt, parser):
         get_help = parser._get_formatter()._expand_help
         return (('{nargs}{options}"[{help}]"' if isinstance(
@@ -483,9 +489,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
                 help=quote(get_help(opt) if opt.help else ""),
                 dest=opt.dest,
                 pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
-                    opt, "complete") else
-                (choice_type2fn[opt.choices[0].type] if isinstance(opt.choices[0], Choice) else
-                 "({})".format(" ".join(map(str, opt.choices)))) if opt.choices else "",
+                    opt, "complete") else choices2pattern(opt.choices) if opt.choices else "",
             ).replace('""', ""))
 
     def format_positional(opt, parser):
@@ -495,9 +499,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
                    REMAINDER: "(-)*:"}.get(opt.nargs, ""),
             help=quote((get_help(opt) if opt.help else opt.dest).strip().split("\n")[0]),
             pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
-                opt, "complete") else
-            (choice_type2fn[opt.choices[0].type] if isinstance(opt.choices[0], Choice) else
-             "({})".format(" ".join(map(str, opt.choices)))) if opt.choices else "",
+                opt, "complete") else choices2pattern(opt.choices) if opt.choices else "",
         )
 
     # {cmd: {"help": help, "arguments": [arguments]}}

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -203,6 +203,19 @@ def test_custom_complete(shell, caplog):
     assert not caplog.record_tuples
 
 
+def test_zsh_non_sequence_choices(caplog):
+    parser = ArgumentParser(prog="test")
+    parser.add_argument("--mapping", choices={"one": 1, "two": 2})
+    parser.add_argument("posA", choices={"three"})
+
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell="zsh")
+
+    assert ':mapping:(one two)"' in completion
+    assert '":posA:(three)"' in completion
+    assert not caplog.record_tuples
+
+
 def test_zsh_remainder_custom_complete_has_optional_message_colon(caplog):
     parser = ArgumentParser(prog="test")
     parser.add_argument("command", nargs=1).complete = {"zsh": "{_command_names -e}"}


### PR DESCRIPTION
Closes #214

`argparse` allows any container for `choices` (sets, dicts, ...), but the zsh
generator detected a shtab `Choice` via `opt.choices[0]`, which raises for
non-subscriptable containers — `add_argument("--foo", choices={"a": 1})` fails
with `KeyError: 0`. It now peeks at the first element with `next(iter(...))`,
through a small helper shared by the optional and positional formatters.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
