### PR TITLE
fix(zsh): treat nargs=0 custom actions as flags

### DIFF
--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -475,20 +475,24 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
     def is_opt_multiline(opt):
         return isinstance(opt, OPTION_MULTI)
 
+    def is_opt_flag(opt):
+        return isinstance(opt, FLAG_OPTION) or opt.nargs == 0
+
     def format_optional(opt, parser):
         get_help = parser._get_formatter()._expand_help
-        return (('{nargs}{options}"[{help}]"' if isinstance(
-            opt, FLAG_OPTION) else '{nargs}{options}"[{help}]:{dest}:{pattern}"').format(
-                nargs=('"(- : *)"' if is_opt_end(opt) else '"*"' if is_opt_multiline(opt) else ""),
-                options=("{{{}}}".format(",".join(opt.option_strings)) if len(opt.option_strings)
-                         > 1 else '"{}"'.format("".join(opt.option_strings))),
-                help=quote(get_help(opt) if opt.help else ""),
-                dest=opt.dest,
-                pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
-                    opt, "complete") else
-                (choice_type2fn[opt.choices[0].type] if isinstance(opt.choices[0], Choice) else
-                 "({})".format(" ".join(map(str, opt.choices)))) if opt.choices else "",
-            ).replace('""', ""))
+        return (('{nargs}{options}"[{help}]"'
+                 if is_opt_flag(opt) else '{nargs}{options}"[{help}]:{dest}:{pattern}"').format(
+                     nargs=('"(- : *)"'
+                            if is_opt_end(opt) else '"*"' if is_opt_multiline(opt) else ""),
+                     options=("{{{}}}".format(",".join(opt.option_strings)) if len(
+                         opt.option_strings) > 1 else '"{}"'.format("".join(opt.option_strings))),
+                     help=quote(get_help(opt) if opt.help else ""),
+                     dest=opt.dest,
+                     pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
+                         opt, "complete") else
+                     (choice_type2fn[opt.choices[0].type] if isinstance(opt.choices[0], Choice)
+                      else "({})".format(" ".join(map(str, opt.choices)))) if opt.choices else "",
+                 ).replace('""', ""))
 
     def format_positional(opt, parser):
         get_help = parser._get_formatter()._expand_help

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import subprocess
-from argparse import ArgumentParser
+from argparse import SUPPRESS, Action, ArgumentParser
 
 import pytest
 
@@ -230,6 +230,23 @@ def test_zsh_remainder_custom_complete_has_optional_message_colon(caplog):
 
     assert '"(-)*::args:_normal"' in completion
     assert '"(-)*:args:_normal"' not in completion
+    assert not caplog.record_tuples
+
+
+def test_zsh_custom_action_nargs_zero_takes_no_argument(caplog):
+    class CustomFlagAction(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            pass
+
+    parser = ArgumentParser(prog="test", add_help=False)
+    parser.add_argument("--help", "-h", action=CustomFlagAction, help="Helpy", nargs=0,
+                        default=SUPPRESS)
+
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell="zsh")
+
+    assert '{--help,-h}"[Helpy]"' in completion
+    assert '{--help,-h}"[Helpy]:help:"' not in completion
     assert not caplog.record_tuples
 
 


### PR DESCRIPTION
Closes #215

An optional argument declared with a custom `argparse.Action` and `nargs=0` takes no value, but `complete_zsh()` only recognised the built-in `FLAG_OPTION` action types, so the issue's example rendered as `{--help,-h}"[Helpy]:help:"` — zsh prompted for an argument the parser never accepts (and previously showed the suppressed default in that slot). `format_optional()` now also treats any action with `nargs == 0` as a flag.

Regression test added in `tests/test_shtab.py`; it fails on `main` and passes with the fix. `flake8` and `yapf` are clean on both changed files.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
