### PR TITLE
zsh: restore escape_zsh for help text

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python }}
+    - run: sudo apt-get update && sudo apt-get install -y zsh  # for generated-script tests
     - run: pip install -e .[dev]
     - run: pytest --cov-report=xml --cov-report=term
     - uses: codecov/codecov-action@v7

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -459,10 +459,7 @@ def escape_zsh(string):
     """
     Backslash-escape for interpolation into a double-quoted `_arguments` spec.
 
-    NB: `shlex.quote` is unusable here. It returns a self-contained shell *word*
-    (single-quoted, with `'` written as `'"'"'`), which is only valid at the top
-    level. The specs below embed the result inside `"..."`, where those quotes are
-    literal and unbalance the surrounding string.
+    NOTE: cannot use `shlex.quote` (a single-quoted word only valid at top level).
     """
     # excessive but safe
     return re.sub(r"([^\w\s.,()-])", r"\\\1", str(string))
@@ -505,7 +502,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
                             if is_opt_end(opt) else '"*"' if is_opt_multiline(opt) else ""),
                      options=("{{{}}}".format(",".join(opt.option_strings)) if len(
                          opt.option_strings) > 1 else '"{}"'.format("".join(opt.option_strings))),
-                     help=escape_zsh(get_help(opt) if opt.help else ""),
+                     help=escape_zsh(get_help(opt)) if opt.help else "",
                      dest=opt.dest,
                      pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
                          opt, "complete") else choices2pattern(opt.choices) if opt.choices else "",

--- a/shtab/__init__.py
+++ b/shtab/__init__.py
@@ -455,6 +455,19 @@ complete -o filenames -F ${root_prefix} ${prog}""").safe_substitute(
     )
 
 
+def escape_zsh(string):
+    """
+    Backslash-escape for interpolation into a double-quoted `_arguments` spec.
+
+    NB: `shlex.quote` is unusable here. It returns a self-contained shell *word*
+    (single-quoted, with `'` written as `'"'"'`), which is only valid at the top
+    level. The specs below embed the result inside `"..."`, where those quotes are
+    literal and unbalance the surrounding string.
+    """
+    # excessive but safe
+    return re.sub(r"([^\w\s.,()-])", r"\\\1", str(string))
+
+
 @mark_completer("zsh")
 def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
     """
@@ -492,7 +505,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
                             if is_opt_end(opt) else '"*"' if is_opt_multiline(opt) else ""),
                      options=("{{{}}}".format(",".join(opt.option_strings)) if len(
                          opt.option_strings) > 1 else '"{}"'.format("".join(opt.option_strings))),
-                     help=quote(get_help(opt) if opt.help else ""),
+                     help=escape_zsh(get_help(opt) if opt.help else ""),
                      dest=opt.dest,
                      pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
                          opt, "complete") else choices2pattern(opt.choices) if opt.choices else "",
@@ -503,7 +516,7 @@ def complete_zsh(parser, root_prefix=None, preamble="", choice_functions=None):
         return '"{nargs}:{help}:{pattern}"'.format(
             nargs={ONE_OR_MORE: "(*)", ZERO_OR_MORE: "(*):",
                    REMAINDER: "(-)*:"}.get(opt.nargs, ""),
-            help=quote((get_help(opt) if opt.help else opt.dest).strip().split("\n")[0]),
+            help=escape_zsh((get_help(opt) if opt.help else opt.dest).strip().split("\n")[0]),
             pattern=complete2pattern(opt.complete, "zsh", choice_type2fn) if hasattr(
                 opt, "complete") else choices2pattern(opt.choices) if opt.choices else "",
         )

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -1,6 +1,7 @@
 """Tests for `shtab`."""
 import logging
 import os
+import shutil
 import subprocess
 from argparse import SUPPRESS, Action, ArgumentParser
 
@@ -218,6 +219,44 @@ def test_custom_complete(shell, caplog):
         shell.test('"$($_shtab_test_pos_0_COMPGEN o)" = "one"')
 
     assert not caplog.record_tuples
+
+
+def zsh_spec_array(completion, name, tmp_path):
+    """`zsh -n` the completion, then return the values zsh assigns to array `name`."""
+    syntax = subprocess.run(["zsh", "-n"], input=completion, capture_output=True, text=True)
+    assert syntax.returncode == 0, f"invalid zsh syntax: {syntax.stderr}\n{completion}"
+
+    script = tmp_path / "completion.zsh"
+    script.write_text(completion)
+    # `eval` so the script registers itself rather than running `compdef` (unavailable here)
+    values = subprocess.run(
+        ["zsh", "-f", "-c", f'eval "$(<{script})" 2>/dev/null; print -rl -- "${{(@){name}}}"'],
+        capture_output=True, text=True)
+    return values.stdout.splitlines()
+
+
+@pytest.mark.parametrize("help_text", [
+    "plain help", "don't do this", "e.g. '>size_added,path'", 'a "quoted" value',
+    "cost: $5 (100%%) `tick`"])
+def test_zsh_help_quoting(help_text, tmp_path, caplog):
+    """Help must not gain stray quotes: https://github.com/tqdm/shtab/issues/224"""
+    parser = ArgumentParser(prog="test", add_help=False)
+    parser.add_argument("--opt", help=help_text)
+
+    with caplog.at_level(logging.INFO):
+        completion = shtab.complete(parser, shell="zsh")
+
+    # `shlex.quote`'s `'"'"'` idiom is invalid inside the double-quoted specs
+    assert "'\"'\"'" not in completion
+    assert not caplog.record_tuples
+
+    if not shutil.which("zsh"):
+        pytest.skip("zsh not available")
+    specs = zsh_spec_array(completion, "_shtab_test_options", tmp_path)
+    assert len(specs) == 1, f"quoting split the spec into {len(specs)} words: {specs}"
+    # `_arguments` strips the backslashes; what must not appear is *extra* quotes
+    assert specs[0].count("'") == help_text.count("'")
+    assert specs[0].count('"') == help_text.count('"')
 
 
 def test_zsh_non_sequence_choices(caplog):

--- a/tests/test_shtab.py
+++ b/tests/test_shtab.py
@@ -223,6 +223,8 @@ def test_custom_complete(shell, caplog):
 
 def zsh_spec_array(completion, name, tmp_path):
     """`zsh -n` the completion, then return the values zsh assigns to array `name`."""
+    if not shutil.which("zsh"):
+        pytest.skip("zsh not available")
     syntax = subprocess.run(["zsh", "-n"], input=completion, capture_output=True, text=True)
     assert syntax.returncode == 0, f"invalid zsh syntax: {syntax.stderr}\n{completion}"
 
@@ -250,8 +252,6 @@ def test_zsh_help_quoting(help_text, tmp_path, caplog):
     assert "'\"'\"'" not in completion
     assert not caplog.record_tuples
 
-    if not shutil.which("zsh"):
-        pytest.skip("zsh not available")
     specs = zsh_spec_array(completion, "_shtab_test_options", tmp_path)
     assert len(specs) == 1, f"quoting split the spec into {len(specs)} words: {specs}"
     # `_arguments` strips the backslashes; what must not appear is *extra* quotes


### PR DESCRIPTION
Fixes #224 — the zsh half of the #196 regression (the bash half is already fixed by e131b910aebd6d86395baf758080b1bcb33d19f4).

## The problem

`shlex.quote` returns a self-contained shell *word*: single-quoted, with an embedded `'` written as `'"'"'`. That is only valid at the top level. But `format_optional` and `format_positional` interpolate the result **inside** `"…"`:

```python
'{nargs}{options}"[{help}]:{dest}:{pattern}"'
```

There those quotes are literal, so the parity flips and the remainder of the spec goes unquoted. Two symptoms:

**Every** description with a space gained stray literal `'`, because `shlex.quote` quotes on spaces alone:

```zsh
# before (what zsh actually assigns)
(- : *)--help['show this help message and exit']
# after
(- : *)--help[show this help message and exit]
```

And a single apostrophe anywhere left an *unterminated* quote that cascaded down the file until it reached shtab's own `default='*::: :->{name}'`, whose `->` then parsed as a redirection:

```console
$ borg completion zsh | zsh -n
(stdin):715: parse error near `>'
```

## The fix

Restore `escape_zsh()` for the two call sites that interpolate into `"…"`. Backslash-escaping is safe there, and `_arguments` strips the backslashes when it parses the spec — which is why this worked from 1.8.0 through 1.8.1.

`command_list` and the bash/fish call sites use `quote()` in bare-word context, where it *is* correct — left alone.

## Test

`test_zsh_help_quoting` checks generated specs against real zsh rather than comparing text: `zsh -n` for syntax, then the values zsh assigns to the spec array, asserting the escaping introduces no *extra* quotes. It fails on all five help variants without the source change — including plain `"plain help"`, which shows the breakage wasn't limited to apostrophes:

```
E   assert 2 == 0
E    +  where 2 = "--opt['plain help']:opt:".count("'")
E    +  and   0 = 'plain help'.count("'")
```

Skipped via `shutil.which("zsh")` when zsh is unavailable.

## Verification

- `pytest`: 83 passed, coverage 87% (the one failure here, `test_path_completion_after_redirection`, is pre-existing on `main` — local bash 3.2 on macOS).
- flake8, isort, yapf, mypy: clean.
- End-to-end on borgbackup (https://github.com/borgbackup/borg/issues/9982): `borg completion zsh | zsh -n` passes again, and borg's completion test suite returns to its exact 1.8.1 result.

## Known pre-existing issue, deliberately not touched

`format_positional` puts help in `_arguments`' `message` field, which is `:`-delimited. A `:` in help is escaped to `\:` and does reach `_arguments` correctly, but I did not audit that path further — it behaves identically to 1.8.1, so it's out of scope for this regression fix. Happy to look at it separately if you'd like.

# Please review!

Note: fix is AI generated by Claude Opus 5. I did not review it.