### PR TITLE
CI: diff examples warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,39 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{ matrix.python }}
+  diff:
+    if: (github.event_name != 'pull_request' || !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)) && github.ref != 'main'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+      with: {fetch-depth: 0}
+    - uses: actions/setup-python@v7
+      with: {python-version: '3.x'}
+    - name: diff examples
+      run: |
+        pip install -e .
+        git checkout main
+        SHELLS=$(python -c "import shtab; print(' '.join(shtab.SUPPORTED_SHELLS))")
+        git checkout -
+        ref=$(git rev-parse --abbrev-ref HEAD)
+        mkdir -p "$ref" main
+        for s in $SHELLS; do
+          echo "::group::$s"
+          for r in main "$ref"; do
+            git checkout -
+            python examples/pathcomplete.py -s $s > "$r/pathcomplete.$s" || :
+            python examples/customcomplete.py completion $s > "$r/customcomplete.$s" || :
+          done
+          for ex in pathcomplete customcomplete; do
+            d=$(diff {main,"$ref"}/$ex.$s || :)
+            if test -n "$d"; then
+              echo "::warning file=examples/$ex.py,line=1,title=$s::changes detected"
+              echo -e "# warning: $ex.$s\n\n\`\`\`diff\n$d\n\`\`\`\n\n" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          echo "::endgroup::"
+        done
+        test -z "$(cat "$GITHUB_STEP_SUMMARY")"
   deploy:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Check branches/PRs against `main` for changes in `examples/{path,custom}complete.py` output.

Makes it much easier to detect & debug unexpected changes such as those caused by #196
